### PR TITLE
chore: bump humanbound-cli compat stub to 1.2.1 for 2.0.1 release

### DIFF
--- a/compat/humanbound-cli/pyproject.toml
+++ b/compat/humanbound-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound-cli"
-version = "1.2.0"
+version = "1.2.1"
 description = "DEPRECATED: renamed to 'humanbound'"
 readme = "README.md"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "humanbound==2.0.0",
+    "humanbound==2.0.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Bump the compat stub's own version and its pin on the main package so the 2.0.1 release workflow can publish it to PyPI. Without this, `git push origin v2.0.1` would succeed in publishing `humanbound 2.0.1` but fail the `Publish humanbound-cli stub to PyPI` job because 1.2.0 is already on PyPI and can't be re-uploaded.

- `compat/humanbound-cli/pyproject.toml`: `version 1.2.0 → 1.2.1`
- `compat/humanbound-cli/pyproject.toml`: `humanbound==2.0.0` → `humanbound==2.0.1`

Should have been part of PR #7 — isolating here now so 2.0.1 tagging can proceed cleanly.

## Test plan

- [ ] CI passes (lint, tests, build)
- [ ] After merge, `git tag v2.0.1 && git push origin v2.0.1` publishes both `humanbound 2.0.1` and `humanbound-cli 1.2.1` to PyPI