### PR TITLE
docs: drop legal-entity footer from README/CONTRIBUTING/ROADMAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,3 @@ for the current cadence and supported-version matrix.
 Participation is governed by our [Code of Conduct](./CODE_OF_CONDUCT.md).
 Violations can be reported privately to
 [conduct@humanbound.ai](mailto:conduct@humanbound.ai).
-
----
-
-_Humanbound is the trading name of AI and Me Single-Member Private Company,
-incorporated in Greece._

--- a/README.md
+++ b/README.md
@@ -134,9 +134,3 @@ trademark policy. The code is open; the name is not.
 The sibling project [`humanbound-firewall`](https://github.com/humanbound/humanbound-firewall)
 is dual-licensed (AGPL-3.0 + commercial) — different product, different
 license strategy.
-
----
-
-<p align="center">
-  <sub><em>Humanbound is the trading name of AI and Me Single-Member Private Company, incorporated in Greece.</em></sub>
-</p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,8 +44,3 @@ The authoritative, continuously-updated roadmap lives at
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for how changes ship and the semver
 policy. The supported-version matrix is on the docs site.
-
----
-
-_Humanbound is the trading name of AI and Me Single-Member Private Company,
-incorporated in Greece._


### PR DESCRIPTION
## Summary
- Remove the "_Humanbound is the trading name of AI and Me Single-Member Private Company, incorporated in Greece._" footer from README, CONTRIBUTING, and ROADMAP.
- Corporate-entity language lives in LICENSE, TRADEMARK.md, and CLA.md — repeating it in user-facing docs adds noise without legal value.

## Test plan
- [x] `pre-commit run --files README.md CONTRIBUTING.md ROADMAP.md` passes
- [ ] Rendered README / CONTRIBUTING / ROADMAP on GitHub look clean (no orphan `---` or stray whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)