### PR TITLE
docs(mcp): expand setup with install command and Claude Code scopes

### DIFF
--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -4,7 +4,40 @@ Humanbound exposes an **MCP (Model Context Protocol) server** that lets AI codin
 
 ## Setup
 
-The MCP server is built into the Humanbound CLI. Configure it in your IDE's MCP settings:
+The MCP server is built into the Humanbound CLI and ships as an extra. Install it first:
+
+```bash
+pip install 'humanbound[mcp]'
+```
+
+!!! tip "zsh users"
+    Quote the extras (`'humanbound[mcp]'`) — unquoted, zsh treats `[mcp]` as a glob and fails with `no matches found`.
+
+`hb mcp` speaks MCP over **stdio** and is meant to be spawned by an MCP client (Claude Code, Cursor, Windsurf, etc.) — don't run it manually in a terminal.
+
+### Claude Code
+
+Register the server with the `claude` CLI instead of hand-editing JSON:
+
+```bash
+claude mcp add humanbound -- hb mcp                 # this project, just you (default)
+claude mcp add -s user humanbound -- hb mcp         # all your projects
+claude mcp add -s project humanbound -- hb mcp      # commit to repo (.mcp.json)
+```
+
+Scopes write to:
+
+| Scope | Stored in | Visible to |
+|---|---|---|
+| `local` (default) | project `.claude/settings.local.json` | only you, only this project |
+| `user` | `~/.claude.json` | only you, every project |
+| `project` | `.mcp.json` (committed) | anyone who clones the repo |
+
+Verify with `claude mcp list`. Note: `claude mcp` only configures Claude Code — Claude Desktop reads a separate config.
+
+### Other clients
+
+For IDEs/clients that take a JSON config directly:
 
 ```json
 {
@@ -16,6 +49,8 @@ The MCP server is built into the Humanbound CLI. Configure it in your IDE's MCP 
   }
 }
 ```
+
+If your client launches with a minimal `PATH` and can't find `hb`, replace `"hb"` with the absolute path from `which hb`.
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

- Adds the missing `pip install 'humanbound[mcp]'` install step, with a tip about quoting extras under zsh.
- Adds `claude mcp add` invocations as the recommended path for Claude Code users, plus a scope reference table (`local` / `user` / `project`) explaining where each scope writes and who sees it.
- Splits the existing JSON snippet into an "Other clients" subsection and adds a PATH note for clients that launch with a minimal environment and can't find `hb`.

## Test plan

- [ ] `mkdocs serve` (or the project's docs preview script) — verify the page renders with the new sections + admonition box
- [ ] Copy/paste each command snippet into a fresh shell to confirm correctness
- [ ] Visual diff review on the rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)