### PR TITLE
fix(auth): revoke backend session on hb logout (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`hb logout` now revokes the backend session, not just local credentials.**
+  Previously `HumanboundClient.logout()` only cleared the in-memory token
+  state and the local token file, so the API session (and any concurrent
+  platform or CLI session for the same user) stayed valid. Logout now calls
+  `GET /logout` with the current API token before clearing local state.
+  The call is best-effort so offline logout still works (#13).
+
 ### Removed
 - **`compat/humanbound-cli/` and its CI publish jobs.** The transitional
   `humanbound-cli` PyPI stub was discontinued at 1.2.2 (released alongside

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -35,7 +35,7 @@ Opens your browser for OAuth authentication. Credentials are stored locally at `
 ## Logout
 
 ```bash
-# Clear local credentials
+# Revoke the backend session and clear local credentials
 hb logout
 
 # Also revoke browser session
@@ -44,6 +44,8 @@ hb logout --revoke
 # Custom callback port for revoke (default: 8085)
 hb logout --revoke --port 9090
 ```
+
+`hb logout` revokes the backend session, signing out any active session on the Humanbound platform or CLI for the same user. Use `--revoke` to also clear the Auth0 SSO browser cookie.
 
 ## Check Authentication Status
 

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -436,11 +436,21 @@ class HumanboundClient:
         return True
 
     def logout(self, silent: bool = False) -> None:
-        """Clear stored credentials and logout.
+        """Revoke the server session (if any) and clear stored credentials.
 
         Args:
             silent: If True, don't print success message (used for cleanup).
         """
+        if self._api_token:
+            try:
+                requests.get(
+                    f"{self.base_url}/logout",
+                    headers={"Authorization": f"Bearer {self._api_token}"},
+                    timeout=DEFAULT_TIMEOUT,
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                pass
+
         self._auth0_token = None
         self._api_token = None
         self._token_expires_at = None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -10,6 +10,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from humanbound_cli.client import HumanboundClient
 from humanbound_cli.exceptions import (
@@ -92,7 +93,9 @@ class TestAuthentication:
         with pytest.raises(NotAuthenticatedError, match="Not authenticated"):
             unauthenticated_client._ensure_authenticated()
 
-    def test_logout_clears_state(self, client, tmp_path):
+    @patch("humanbound_cli.client.requests.get")
+    def test_logout_clears_state(self, mock_get, client, tmp_path):
+        mock_get.return_value = _mock_response(204)
         token_file = tmp_path / ".humanbound" / "credentials.json"
         token_file.write_text(json.dumps({"api_token": "x"}))
 
@@ -102,6 +105,54 @@ class TestAuthentication:
         assert client._organisation_id is None
         assert client._project_id is None
         assert not token_file.exists()
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_logout_calls_server_revoke(self, mock_get, client):
+        """Logout must notify the server so concurrent sessions
+        (platform, other terminals) are also revoked."""
+        mock_get.return_value = _mock_response(204)
+
+        client.logout(silent=True)
+
+        mock_get.assert_called_once()
+        call = mock_get.call_args
+        url = call.args[0] if call.args else call.kwargs.get("url")
+        assert url == "http://test.local/api/logout"
+        headers = call.kwargs.get("headers", {})
+        assert headers["Authorization"] == "Bearer test-token"
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_logout_swallows_network_error(self, mock_get, client, tmp_path):
+        """Offline users must still be able to log out locally."""
+        mock_get.side_effect = requests.ConnectionError("offline")
+        token_file = tmp_path / ".humanbound" / "credentials.json"
+        token_file.write_text(json.dumps({"api_token": "x"}))
+
+        client.logout(silent=True)
+
+        assert client._api_token is None
+        assert not token_file.exists()
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_logout_swallows_non_2xx(self, mock_get, client, tmp_path):
+        """An already-expired token is effectively logged out — non-2xx must
+        not block local cleanup."""
+        mock_get.return_value = _mock_response(401, {"message": "Token expired"})
+        token_file = tmp_path / ".humanbound" / "credentials.json"
+        token_file.write_text(json.dumps({"api_token": "x"}))
+
+        client.logout(silent=True)
+
+        assert client._api_token is None
+        assert not token_file.exists()
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_logout_skips_server_when_no_token(self, mock_get, unauthenticated_client):
+        """Without an API token there is no session to revoke — don't call
+        the server."""
+        unauthenticated_client.logout(silent=True)
+
+        mock_get.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HumanboundClient.logout() previously only cleared the local token file, leaving the API session valid for any concurrent client (platform, second terminal). It now calls GET /logout with the current API token before clearing local state. Best-effort: ConnectionError/Timeout are swallowed so offline logout still works, and non-2xx responses are ignored since an already-expired token is effectively logged out.

<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

<!-- What does this change do and why? -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [ ] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

Fixes #13

<!-- Fixes #123 / closes #456 -->
