### PR TITLE
refactor: slim collected experiment stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] — 2026-05-05
+
+### Changed
+- Slimmed the experiment stats schema. The HTML report's defense-rate
+  KPI is now computed from pass/fail counts at render time.
+
 ### Fixed
 - **`hb logout` now revokes the backend session, not just local credentials.**
   Previously `HumanboundClient.logout()` only cleared the in-memory token

--- a/humanbound_cli/engine/presenter.py
+++ b/humanbound_cli/engine/presenter.py
@@ -138,13 +138,6 @@ def run(testing_configuration, logs, test_category=""):
         posture = {
             "posture": posture_score,
             "grade": grade,
-            "tests": successful,
-            "defense_rate": round(defense_rate, 4),
-            "confidence": confidence,
-            "domain": domain,
-            "breach_breadth": round(breach_ratio, 4),
-            "breached": breached,
-            "defended": defended,
         }
 
     # --- 3. Lightweight insights (no embeddings, no clustering) ---

--- a/humanbound_cli/engine/runner.py
+++ b/humanbound_cli/engine/runner.py
@@ -53,7 +53,7 @@ class TestResult:
     testing_level: str = ""
     stats: dict = field(default_factory=dict)  # {pass, fail, total, ...}
     insights: list = field(default_factory=list)  # [{result, category, severity, explanation}]
-    posture: dict = field(default_factory=dict)  # {posture, grade, defense_rate, ...}
+    posture: dict = field(default_factory=dict)  # {posture, grade, dimensions}
     exec_t: dict = field(default_factory=dict)  # {max_t, min_t, avg_t}
 
 

--- a/humanbound_cli/engine/schemas.py
+++ b/humanbound_cli/engine/schemas.py
@@ -183,17 +183,11 @@ class PostureDimensions(BaseModel):
 
 
 class ExperimentPosture(BaseModel):
-    """Experiment-level posture computed from ASR."""
+    """Experiment-level posture."""
 
     posture: float = 0
     grade: str = "F"
-    tests: int = 0
-    defense_rate: float = 0
-    confidence: str = "low"
-    domain: str = "security"
-    breach_breadth: float = 0
-    breached: list[str] = []
-    defended: list[str] = []
+    dimensions: PostureDimensions | None = None
 
 
 # ── Experiment Results ─────────────────────────────────────────────────────

--- a/humanbound_cli/report.py
+++ b/humanbound_cli/report.py
@@ -186,7 +186,7 @@ def generate_html_report(experiment, logs):
     posture_grade = (
         posture_data.get("grade", _score_to_grade(posture_score)) if posture_data else "F"
     )
-    defense_rate = posture_data.get("defense_rate", 0) if posture_data else 0
+    defense_rate = (passed / (passed + failed)) if (passed + failed) > 0 else 0
 
     # ── Build report body ──────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.0.2"
+version = "2.0.3"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Slim the locally-stored experiment stats schema.
- HTML report's defense rate is now computed from pass/fail counts at render time.
- Bumps to 2.0.3.

## Test plan
- [ ] `hb logs <experiment-id> --html out.html` renders correctly, defense rate value matches `pass / (pass + fail)`.
- [ ] Existing CLI commands behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)