### PR TITLE
fix: validate context length before project creation in hb_connect

### DIFF
--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -1403,9 +1403,7 @@ def hb_connect(
             return _err(ValueError("No organisation selected. Use hb_set_organisation first."))
 
         if context and len(context) > 1500:
-            return _err(
-                ValueError(f"Context too long ({len(context)} chars). Maximum is 1,500.")
-            )
+            return _err(ValueError(f"Context too long ({len(context)} chars). Maximum is 1,500."))
 
         # -- Parse endpoint config ----------------------------------------
         try:

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -1402,6 +1402,11 @@ def hb_connect(
         if not client.organisation_id:
             return _err(ValueError("No organisation selected. Use hb_set_organisation first."))
 
+        if context and len(context) > 1500:
+            return _err(
+                ValueError(f"Context too long ({len(context)} chars). Maximum is 1,500.")
+            )
+
         # -- Parse endpoint config ----------------------------------------
         try:
             bot_config = json.loads(endpoint_config)
@@ -1467,12 +1472,6 @@ def hb_connect(
 
                 configuration = {}
                 if context:
-                    if len(context) > 1500:
-                        return _err(
-                            ValueError(
-                                f"Context too long ({len(context)} chars). Maximum is 1,500."
-                            )
-                        )
                     configuration["context"] = context
 
                 import time as _time


### PR DESCRIPTION
## Summary

In `hb_connect`, the `context` length validation was happening after the project had already been created in the backend. If the validation failed, the function returned an error, but the project persisted silently on the user's account.

- Move `context` length check to the top of the function, alongside the other input validations, before any API calls
- Remove the redundant inline check from the middle of the function

## Why this matters

If a user passed a `context` string longer than 1,500 characters, they would receive an error response with no indication that a project was created. Retrying would create additional orphaned projects. This is particularly problematic for automated pipelines using the MCP tool, where retries happen without human oversight.

## Changes

- `humanbound_cli/mcp_server.py` — moved context validation before `POST /scan` and `POST /projects`

## Test plan

- [x] `hb_connect` with `context` > 1,500 chars returns error and creates no project
- [x] `hb_connect` with valid `context` behaves as before
- [x] `hb_connect` without `context` behaves as before