### PR TITLE
release: prep 2.0.3 notes and enable social cards on docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,5 +13,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - run: pip install mkdocs-material
+      - name: Install Cairo/Pango (required by mkdocs-material social plugin)
+        run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libpango1.0-dev libpangocairo-1.0-0
+      - run: pip install "mkdocs-material[imaging]"
       - run: cd docs && mkdocs gh-deploy --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--unsafe]
       - id: check-toml
       - id: check-added-large-files
         args: [--maxkb=500]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.3] — 2026-05-05
+## [2.0.3] — 2026-05-11
 
 ### Changed
 - Slimmed the experiment stats schema. The HTML report's defense-rate
   KPI is now computed from pass/fail counts at render time.
 
 ### Fixed
+- **`hb connect` no longer creates orphaned projects when `--context`
+  exceeds 1,500 chars.** The length check previously ran after
+  `POST /scan` and `POST /projects`, so an over-long context returned an
+  error to the caller but left a project registered on the backend. Each
+  retry created another orphan — particularly problematic for the
+  MCP-driven auto-retry path. The validation now runs alongside the other
+  input guards, before any API call.
 - **`hb logout` now revokes the backend session, not just local credentials.**
   Previously `HumanboundClient.logout()` only cleared the in-memory token
   state and the local token file, so the API session (and any concurrent

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,14 @@
-site_name: ""
+site_name: Humanbound
 site_url: https://docs.humanbound.ai
+site_description: Humanbound documentation — AI security testing, continuous monitoring, and defense for LLM agents.
 repo_url: https://github.com/humanbound/humanbound
+
+plugins:
+  - search
+  - social:
+      cards_layout_options:
+        background_color: "#0a0a0a"
+        color: "#ffffff"
 
 theme:
   name: material

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -15,11 +15,6 @@
     </label>
     <div class="md-header__title" data-md-component="header-title">
       <div class="md-header__ellipsis">
-        <div class="md-header__topic">
-          <span class="md-ellipsis">
-            {{ config.site_name }}
-          </span>
-        </div>
         <div class="md-header__topic" data-md-component="header-topic">
           <span class="md-ellipsis">
             {% if page.meta and page.meta.title %}


### PR DESCRIPTION
## Summary
- CHANGELOG: document the `hb_connect` orphan-project fix under 2.0.3; bump 2.0.3 release date to today.
- Docs: enable the MkDocs Material `social` plugin so shared links render with a per-page OG preview card.
- Pre-commit: allow custom YAML tags so `mkdocs.yml` parses cleanly.

## Test plan
- [x] CI green.
- [x] Local docs build succeeds with the social plugin enabled.
- [x] After deploy, OG / Twitter Card tags render on a docs page.