### PR TITLE
chore: remove leftover references to deprecated hb sentinel CLI

### DIFF
--- a/docs/docs/integrations/siem.md
+++ b/docs/docs/integrations/siem.md
@@ -68,67 +68,7 @@ def verify(body: bytes, secret: str, signature: str) -> bool:
     return hmac.compare_digest(expected, received)
 ```
 
-## Microsoft Sentinel
-
-The Humanbound Sentinel Connector deploys a dedicated Azure Function into the customer's Azure subscription. Webhook events are pushed to a Log Analytics custom table (`AISecurityEvents_CL`) and surfaced through pre-built Sentinel content:
-
-- **CISO Dashboard** -- 5-tab workbook: Executive Summary, Findings, Drift & Resilience, ASCAM Lifecycle, Incidents
-- **4 Analytic Rules** -- Auto-create Sentinel incidents for critical findings, regressions, posture drops, and drift
-- **6 Hunting Queries** -- OWASP risk analysis, regression patterns, posture trends, drift timeline, campaign ROI, remediation velocity
-- **AI Estate Coverage** -- Dashboard tiles showing actively monitored, paused, and silent projects
-
-### End-to-End Deployment
-
-Deploy the full Sentinel integration with a single command. `hb sentinel deploy` handles everything: infrastructure, connector code, webhook creation, signing secret configuration, and connectivity verification.
-
-```bash
-# Deploy everything and auto-connect (one command, zero manual steps)
-$ hb sentinel deploy --resource-group rg-humanbound
-
-# Custom location and workspace name
-$ hb sentinel deploy --rg rg-demo --location eastus --workspace la-demo
-
-# Deploy infrastructure only, skip webhook setup
-$ hb sentinel deploy --rg rg-humanbound --no-connect
-
-# Export the script to review before running
-$ hb sentinel deploy --rg rg-humanbound --export-only
-
-# Save script to a specific file
-$ hb sentinel deploy --rg rg-humanbound --output deploy.sh
-```
-
-The deploy command runs end-to-end: prerequisite check (az + func) -> Azure login -> resource group -> Bicep deployment -> function code publish -> validation (4 automated checks) -> webhook creation -> signing secret configuration -> test ping. After it completes, open the CISO Dashboard in Sentinel -- events flow immediately.
-
-!!! info "Requirements"
-    Azure CLI (`az`), Azure Functions Core Tools (`func`), and Humanbound login (`hb login`). Use `--no-connect` to skip the login requirement and deploy infrastructure only. Run `hb sentinel` with no subcommand for install instructions.
-
-### Connect & Manage
-
-If you used `--no-connect` or need to reconnect to a different connector, use the individual commands:
-
-```bash
-# Register webhook pointing to your connector (only needed with --no-connect)
-$ hb sentinel connect --url https://func-hb-connector-xxx.azurewebsites.net/api/ingest
-
-# Verify connectivity
-$ hb sentinel test
-
-# Check connector health and recent deliveries
-$ hb sentinel status
-
-# Backfill historical events
-$ hb sentinel sync --since 2025-01-01
-
-# Remove the webhook
-$ hb sentinel disconnect
-```
-
-### Data Sovereignty
-
-The connector runs in **your** Azure subscription. Event data never passes through Humanbound infrastructure -- it flows directly from the webhook to your Log Analytics workspace via the Logs Ingestion API with managed identity authentication.
-
-## Other SIEMs
+## SIEMs
 
 Webhook events can be routed to any SIEM or automation platform that accepts HTTPS webhooks:
 

--- a/docs/docs/reference/commands.md
+++ b/docs/docs/reference/commands.md
@@ -91,19 +91,6 @@ Complete reference of all available commands, organized by category.
 | `hb campaigns terminate` | Stop running campaign |
 | `hb monitor` | Start, pause, or resume continuous monitoring |
 
-## SIEM / Sentinel
-
-| Command | Description |
-|---|---|
-| `hb sentinel` | Show Sentinel setup instructions and available commands |
-| `hb sentinel deploy --rg <name>` | Deploy infrastructure, create webhook, set signing secret, and verify -- fully end-to-end |
-| `hb sentinel deploy --rg <name> --no-connect` | Deploy infrastructure only, skip webhook setup |
-| `hb sentinel connect --url <url>` | Register webhook manually (only needed with --no-connect) |
-| `hb sentinel test` | Send a test event to verify connectivity |
-| `hb sentinel status` | Check connector health and recent deliveries |
-| `hb sentinel sync` | Replay historical events to Sentinel for backfill |
-| `hb sentinel disconnect` | Remove the Sentinel webhook and local configuration |
-
 ## Configuration
 
 | Command | Description |

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -61,8 +61,7 @@ mcp = FastMCP(
         "(hb_set_project).\n\n"
         "CLI-ONLY COMMANDS (suggest when relevant):\n"
         "  • 'hb discover' — browser-based shadow AI discovery (no connector needed)\n"
-        "  • 'hb connect --vendor microsoft' — browser-based platform discovery\n"
-        "  • 'hb sentinel setup' — configure continuous monitoring sentinel"
+        "  • 'hb connect --vendor microsoft' — browser-based platform discovery"
     ),
 )
 


### PR DESCRIPTION
The `hb sentinel` CLI was removed (source file no longer in tree) but three references remained:

- `docs/reference/commands.md` — SIEM/Sentinel table (8 rows)
- `docs/integrations/siem.md` — ~60-line Microsoft Sentinel feature section
- `humanbound_cli/mcp_server.py` — `hb sentinel setup` help string in MCP server instructions

All three removed. Net -76 lines. Other SIEM integration content (HMAC verification, event taxonomy, generic SIEM section) preserved.