### PR TITLE
fix(engine): openai import robustness, hb test backend defaults, posture domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`humanbound_cli.engine.llm.openai` no longer requires the optional OpenAI SDK
+  just to import.** The `from openai import OpenAI` is deferred into `LLMStreamer`
+  (its only consumer); the requests-based `LLMPinger` never needed it, so routing
+  to the OpenAI pinger works without the `[engine]` extra installed.
+- **`hb test` defers `test_category` / `testing_level` / `lang` to the backend when
+  a caller leaves them unset.** `TestConfig` now defaults these to `None`, the
+  platform runner omits unset keys from the request (so the backend applies its
+  defaults), and local mode coalesces them to local defaults. Normal `hb test`
+  usage — which always resolves concrete values — is unchanged.
+
+### Added
+- Presenter posture output now includes a `domain` field (`security` / `quality`,
+  derived from the test category).
+
 ## [2.0.4] — 2026-06-02
 
 ### Added

--- a/humanbound_cli/engine/llm/openai.py
+++ b/humanbound_cli/engine/llm/openai.py
@@ -4,7 +4,6 @@ import time
 from os import getenv
 
 import requests
-from openai import OpenAI
 
 #
 # Handle communications with LLM
@@ -31,6 +30,11 @@ class LLMStreamer:
             if model_provider is None
             else model_provider
         )
+        # Lazy import: the OpenAI SDK is the optional [engine] extra and is only
+        # needed for streaming. Importing it at module top made this submodule
+        # (and the requests-based LLMPinger) un-importable without the extra.
+        from openai import OpenAI
+
         self.__openai_client = OpenAI(
             api_key=model_provider["integration"]["api_key"],
         )

--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -175,9 +175,11 @@ class _LocalRun:
             id=self.experiment_id,
             name=self.config.name,
             status=self.status,
-            test_category=self.config.test_category,
-            testing_level=self.config.testing_level,
-            lang=self.config.lang,
+            # Local mode applies the schema defaults the backend would otherwise
+            # fill when a field is left unset (deferred) on the config.
+            test_category=self.config.test_category or "",
+            testing_level=self.config.testing_level or "",
+            lang=self.config.lang or "english",
             results=exp_results,
             created_at=self._created_at,
             completed_at=time.strftime("%Y-%m-%dT%H:%M:%S"),

--- a/humanbound_cli/engine/platform_runner.py
+++ b/humanbound_cli/engine/platform_runner.py
@@ -23,11 +23,13 @@ class PlatformTestRunner(TestRunner):
         experiment_data = {
             "name": config.name,
             "description": config.description,
-            "test_category": config.test_category,
-            "testing_level": config.testing_level,
-            "lang": config.lang,
             "auto_start": config.auto_start,
         }
+        # Omit category/level/lang when unset so the backend applies its defaults.
+        for key in ("test_category", "testing_level", "lang"):
+            value = getattr(config, key)
+            if value is not None:
+                experiment_data[key] = value
 
         if config.provider_id:
             experiment_data["provider_id"] = config.provider_id

--- a/humanbound_cli/engine/presenter.py
+++ b/humanbound_cli/engine/presenter.py
@@ -138,6 +138,7 @@ def run(testing_configuration, logs, test_category=""):
         posture = {
             "posture": posture_score,
             "grade": grade,
+            "domain": domain,
         }
 
     # --- 3. Lightweight insights (no embeddings, no clustering) ---

--- a/humanbound_cli/engine/runner.py
+++ b/humanbound_cli/engine/runner.py
@@ -15,9 +15,12 @@ from dataclasses import dataclass, field
 class TestConfig:
     """Canonical test configuration — identical shape for both runners."""
 
-    test_category: str
-    testing_level: str  # unit | system | acceptance
-    lang: str = "english"
+    # Default to None so a caller that doesn't set these defers to the backend's
+    # defaults (the runner omits unset keys from the request). The `hb test`
+    # command always resolves concrete values, so normal usage is unaffected.
+    test_category: str | None = None
+    testing_level: str | None = None  # unit | system | acceptance
+    lang: str | None = None
     name: str = ""
     description: str = ""
     provider_id: str = ""


### PR DESCRIPTION
## Summary
Three independent engine fixes, surfaced while running the local engine test suite:

- **`llm/openai.py` — lazy SDK import.** `from openai import OpenAI` is deferred into `LLMStreamer` (its only consumer). The requests-based `LLMPinger` never needed it, so importing/using the OpenAI pinger no longer requires the optional `[engine]` extra to be installed.
- **`hb test` — defer config defaults to the backend.** `TestConfig.{test_category,testing_level,lang}` now default to `None`; `PlatformTestRunner.start()` omits unset keys so the backend applies its defaults; `local_runner` coalesces unset fields to local defaults (`""`/`"english"`) before building `ExperimentMeta`. The `hb test` command always resolves concrete values, so **normal usage is unchanged** — this only affects callers that leave fields unset. Aligns with the CLI-mirrors-backend contract.
- **Presenter — surface `domain`.** The already-computed posture `domain` (`security`/`quality`, by test category) is now included in the posture output.

## Notes
- Independent of the Tier-2 firewall branches.
- The engine test suite that validates these lives under `tests/engine/`, which is **gitignored by team policy** (private integration tests containing infra URLs) — so the tests are intentionally not part of this PR. Validated locally: `tests/engine/` 160 passed; tracked public suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)