### PR TITLE
feat(connect): add --no-test, --test-category, --scope flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Presenter posture output now includes a `domain` field (`security` / `quality`,
   derived from the test category).
+- **Three new flags on `hb connect`:**
+  - **`--no-test`** skips the auto-test step after project creation. The
+    project is still created and the risk dashboard still renders; the
+    "Next" hints surface the `hb test` command to run later.
+  - **`--test-category`** chooses which test family the auto-test step
+    launches (default: `humanbound/adversarial/owasp_agentic`). Mirrors the
+    same flag on `hb test` — pass the full category path (e.g.
+    `humanbound/adversarial/owasp_single_turn`). Ignored when `--no-test`
+    is set (warn-and-continue).
+  - **`--scope ./scope.yaml`** loads a pre-made scope file (YAML or JSON)
+    as input. Sent to `POST /scan` as a `text` source only — no agent
+    probing. The backend analyzer returns its own scope; the CLI diffs it
+    against your file and prompts to accept additive `permitted` /
+    `restricted` intents before project creation. `--yes` auto-accepts.
+    `--prompt`/`--repo`/`--openapi` are ignored when `--scope` is set;
+    `--endpoint` is still honoured for `default_integration` but never
+    sent as a scan source.
 
 ## [2.0.4] — 2026-06-02
 

--- a/docs/docs/reference/commands.md
+++ b/docs/docs/reference/commands.md
@@ -38,6 +38,9 @@ The complete `hb` CLI reference, organised into eight categories: global flags, 
 |---|---|
 | `hb connect` | Connect your agent or scan a cloud platform |
 | `hb connect -l system` | Connect with deeper testing level (unit/system/acceptance) |
+| `hb connect --no-test` | Connect and create project but skip the auto-test step |
+| `hb connect --test-category <path>` | Choose which test family the auto-test runs (default: `humanbound/adversarial/owasp_agentic`) |
+| `hb connect --scope ./scope.yaml` | Use a pre-made scope file as input; the backend analyses it and proposes additive intents before project creation |
 | `hb projects list` | List all projects in current org |
 | `hb projects use <id>` | Set active project for subsequent commands |
 | `hb projects show [id]` | Show project details (current or specific) |

--- a/humanbound_cli/commands/connect.py
+++ b/humanbound_cli/commands/connect.py
@@ -21,6 +21,8 @@ from .test import _load_integration, _resolve_context
 console = Console()
 
 SCAN_TIMEOUT = 180
+DEFAULT_TEST_CATEGORY = "humanbound/adversarial/owasp_agentic"
+
 
 # -- Scan progress UI ----------------------------------------------------------
 
@@ -243,11 +245,26 @@ def _resolve_init_mode(
     return "none"
 
 
-def _fire_init_event(mode: str, success: bool, duration_ms: int) -> None:
+def _fire_init_event(
+    mode: str,
+    success: bool,
+    duration_ms: int,
+    *,
+    no_test: bool = False,
+    test_category: str = DEFAULT_TEST_CATEGORY,
+    scope_provided: bool = False,
+) -> None:
     """Emit the `init` telemetry event. Safe to call from try/finally."""
     telemetry.capture(
         "init",
-        {"mode": mode, "success": success, "duration_ms": duration_ms},
+        {
+            "mode": mode,
+            "success": success,
+            "duration_ms": duration_ms,
+            "no_test": no_test,
+            "test_category": test_category,
+            "scope_provided": scope_provided,
+        },
     )
 
 
@@ -341,6 +358,23 @@ def _derive_agent_name(endpoint: str) -> str:
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmations")
 @click.option("--timeout", "-t", type=int, default=SCAN_TIMEOUT, help="Request timeout in seconds")
+@click.option(
+    "--no-test",
+    is_flag=True,
+    default=False,
+    help="Skip the auto-test step after project creation.",
+)
+@click.option(
+    "--test-category",
+    default=None,
+    help="Test category to run (e.g. humanbound/adversarial/owasp_agentic, humanbound/behavioral/qa)",
+)
+@click.option(
+    "--scope",
+    "scope_path",
+    type=click.Path(exists=True),
+    help="Pre-made scope file (YAML/JSON with permitted/restricted intents)",
+)
 def connect_command(
     endpoint,
     name,
@@ -351,6 +385,9 @@ def connect_command(
     level,
     yes,
     timeout,
+    no_test,
+    test_category,
+    scope_path,
 ):
     """Connect your AI agent.
 
@@ -368,38 +405,73 @@ def connect_command(
     success = False
 
     try:
-        has_agent_flags = any([endpoint, prompt, repo, openapi])
+        has_agent_flags = any([endpoint, prompt, repo, openapi, scope_path])
 
         if has_agent_flags:
-            _connect_agent(endpoint, name, prompt, repo, openapi, context, level, yes, timeout)
+            _connect_agent(
+                endpoint,
+                name,
+                prompt,
+                repo,
+                openapi,
+                context,
+                level,
+                yes,
+                timeout,
+                no_test=no_test,
+                test_category_arg=test_category,
+                scope_path=scope_path,
+            )
         else:
             console.print("[yellow]Specify a source:[/yellow]")
             console.print()
             console.print("  hb connect --endpoint ./bot-config.json")
             console.print()
-            console.print("[dim]Use --endpoint, --prompt, --repo, or --openapi.[/dim]")
+            console.print("[dim]Use --endpoint, --prompt, --repo, --openapi, or --scope.[/dim]")
             raise SystemExit(1)
 
         success = True
     finally:
         duration_ms = int((time.monotonic() - start) * 1000)
-        _fire_init_event(mode=mode, success=success, duration_ms=duration_ms)
+        _fire_init_event(
+            mode=mode,
+            success=success,
+            duration_ms=duration_ms,
+            no_test=no_test,
+            test_category=test_category or DEFAULT_TEST_CATEGORY,
+            scope_provided=bool(scope_path),
+        )
 
 
 # -- Agent path ----------------------------------------------------------------
 
 
-def _connect_agent(endpoint, name, prompt, repo, openapi, context, level, yes, timeout):
+def _connect_agent(
+    endpoint,
+    name,
+    prompt,
+    repo,
+    openapi,
+    context,
+    level,
+    yes,
+    timeout,
+    no_test=False,
+    test_category_arg=None,
+    scope_path=None,
+):
     """Agent path: dispatch to Platform flow (authenticated) or local flow (anonymous).
 
     Platform flow creates a project on humanbound.ai with full scope, risk profile,
     regulatory mapping, and auto-test. Local flow derives scope + lightweight
     compliance from the user's configured LLM provider and writes scope.yaml.
     """
-    source_flags = [prompt, endpoint, repo, openapi]
+    source_flags = [prompt, endpoint, repo, openapi, scope_path]
     if not any(source_flags):
         console.print("[yellow]No extraction source provided.[/yellow]")
-        console.print("Use --endpoint, --prompt, --repo, or --openapi to specify a source.")
+        console.print(
+            "Use --endpoint, --prompt, --repo, --openapi, or --scope to specify a source."
+        )
         raise SystemExit(1)
 
     if not name:
@@ -408,96 +480,165 @@ def _connect_agent(endpoint, name, prompt, repo, openapi, context, level, yes, t
     client = HumanboundClient()
     if client.is_authenticated() and client.organisation_id:
         _connect_agent_platform(
-            client, endpoint, name, prompt, repo, openapi, context, level, yes, timeout
+            client,
+            endpoint,
+            name,
+            prompt,
+            repo,
+            openapi,
+            context,
+            level,
+            yes,
+            timeout,
+            no_test=no_test,
+            test_category_arg=test_category_arg,
+            scope_path=scope_path,
         )
     else:
         _connect_agent_local(endpoint, name, prompt, repo, openapi, context, level, yes, timeout)
 
 
 def _connect_agent_platform(
-    client, endpoint, name, prompt, repo, openapi, context, level, yes, timeout
+    client,
+    endpoint,
+    name,
+    prompt,
+    repo,
+    openapi,
+    context,
+    level,
+    yes,
+    timeout,
+    no_test=False,
+    test_category_arg=None,
+    scope_path=None,
 ):
     """Platform flow: POST /scan -> create project -> auto-test -> dashboard."""
+    resolved_category = test_category_arg or DEFAULT_TEST_CATEGORY
+    if no_test and test_category_arg:
+        console.print("[yellow]! --test-category is ignored when --no-test is set.[/yellow]")
+        console.print(f"[dim]  To run later: hb test --test-category {test_category_arg}[/dim]")
+
+    # Warn about redundant scope-source flags when --scope is set.
+    if scope_path and (prompt or repo or openapi):
+        ignored = [
+            f"--{flag}"
+            for flag, val in (("prompt", prompt), ("repo", repo), ("openapi", openapi))
+            if val
+        ]
+        console.print(
+            f"[yellow]! {'/'.join(ignored)} ignored when --scope is set "
+            f"(scope comes from the file).[/yellow]"
+        )
+
     console.print(f"\n[bold]Connecting agent:[/bold] {name}\n")
 
     try:
-        # -- Build sources array for POST /scan --------------------------------
         sources = []
-        text_parts = []
-        runtime_info = None
+        user_scope = None  # Set only when --scope is used
+        local_integration = None  # Set when --endpoint is used with --scope
 
-        # --prompt -> text source
-        if prompt:
-            console.print(f"  [green]\u2713[/green] Loaded prompt: [dim]{prompt}[/dim]")
-            prompt_text = Path(prompt).read_text()
-            text_parts.append(prompt_text)
+        if scope_path:
+            # --scope path: load file, serialize to a single text source.
+            try:
+                user_scope = _load_scope_file(scope_path)
+            except (FileNotFoundError, ValueError) as e:
+                console.print(f"[red]Error:[/red] {e}")
+                raise SystemExit(1)
 
-        # --repo -> agentic or text source
-        if repo:
-            from ..extractors.repo import RepoScanner
-
-            scanner = RepoScanner(repo)
-            with console.status("[dim]Scanning repository...[/dim]"):
-                scan_result = scanner.scan()
-
-            if scan_result:
-                files = scan_result.get("files", [])
-                if scan_result.get("tools"):
-                    console.print(
-                        f"  [green]\u2713[/green] Repository: {len(files)} files, {len(scan_result['tools'])} tools (source: agentic)"
-                    )
-                    sources.append(
-                        {
-                            "source": "agentic",
-                            "data": {
-                                "system_prompt": scan_result.get("system_prompt", ""),
-                                "tools": scan_result.get("tools", []),
-                            },
-                        }
-                    )
-                else:
-                    console.print(f"  [green]\u2713[/green] Repository: {len(files)} files")
-                    combined = scan_result.get("system_prompt", "")
-                    if scan_result.get("readme"):
-                        combined += f"\n\nREADME:\n{scan_result['readme']}"
-                    if combined.strip():
-                        text_parts.append(combined)
-            else:
-                console.print("  [yellow]![/yellow] Repository: no relevant files found")
-
-        # --openapi -> text source
-        if openapi:
-            from ..extractors.openapi import OpenAPIParser
-
-            parser = OpenAPIParser(openapi)
-            with console.status("[dim]Parsing specification...[/dim]"):
-                spec_result = parser.parse()
-
-            if spec_result:
-                operations = spec_result.get("operations", [])
-                console.print(f"  [green]\u2713[/green] OpenAPI spec: {len(operations)} operations")
-                summary_parts = [spec_result.get("description", "API-based agent")]
-                for op in operations:
-                    summary_parts.append(
-                        f"- {op.get('method', 'GET')} {op.get('path', '')}: {op.get('summary', '')}"
-                    )
-                text_parts.append("\n".join(summary_parts))
-            else:
-                console.print("  [yellow]![/yellow] OpenAPI spec: could not parse")
-
-        # --endpoint -> endpoint source (API probing)
-        if endpoint:
-            bot_config = _load_integration(endpoint)
-            chat_ep = bot_config.get("chat_completion", {}).get("endpoint", "")
             console.print(
-                f"  [green]\u2713[/green] Endpoint source: [dim]{chat_ep or '(from config)'}[/dim]"
+                f"  [green]\u2713[/green] Loaded scope: [dim]{Path(scope_path).name}[/dim]"
             )
-            sources.append({"source": "endpoint", "data": bot_config})
+            sources.append(
+                {"source": "text", "data": {"text": _serialize_scope_to_text(user_scope)}}
+            )
 
-        # Merge accumulated text parts into a single text source
-        if text_parts:
-            merged_text = "\n\n---\n\n".join(text_parts)
-            sources.append({"source": "text", "data": {"text": merged_text}})
+            # If --endpoint is also passed, keep its config for default_integration
+            # but DO NOT include it as a /scan source (no agent probing).
+            if endpoint:
+                local_integration = _load_integration(endpoint)
+                chat_ep = local_integration.get("chat_completion", {}).get("endpoint", "")
+                console.print(
+                    f"  [green]\u2713[/green] Endpoint integration: [dim]{chat_ep or '(from config)'}[/dim]"
+                )
+        else:
+            # -- Build sources array for POST /scan --------------------------------
+            text_parts = []
+
+            # --prompt -> text source
+            if prompt:
+                console.print(f"  [green]\u2713[/green] Loaded prompt: [dim]{prompt}[/dim]")
+                prompt_text = Path(prompt).read_text()
+                text_parts.append(prompt_text)
+
+            # --repo -> agentic or text source
+            if repo:
+                from ..extractors.repo import RepoScanner
+
+                scanner = RepoScanner(repo)
+                with console.status("[dim]Scanning repository...[/dim]"):
+                    scan_result = scanner.scan()
+
+                if scan_result:
+                    files = scan_result.get("files", [])
+                    if scan_result.get("tools"):
+                        console.print(
+                            f"  [green]\u2713[/green] Repository: {len(files)} files, {len(scan_result['tools'])} tools (source: agentic)"
+                        )
+                        sources.append(
+                            {
+                                "source": "agentic",
+                                "data": {
+                                    "system_prompt": scan_result.get("system_prompt", ""),
+                                    "tools": scan_result.get("tools", []),
+                                },
+                            }
+                        )
+                    else:
+                        console.print(f"  [green]\u2713[/green] Repository: {len(files)} files")
+                        combined = scan_result.get("system_prompt", "")
+                        if scan_result.get("readme"):
+                            combined += f"\n\nREADME:\n{scan_result['readme']}"
+                        if combined.strip():
+                            text_parts.append(combined)
+                else:
+                    console.print("  [yellow]![/yellow] Repository: no relevant files found")
+
+            # --openapi -> text source
+            if openapi:
+                from ..extractors.openapi import OpenAPIParser
+
+                parser = OpenAPIParser(openapi)
+                with console.status("[dim]Parsing specification...[/dim]"):
+                    spec_result = parser.parse()
+
+                if spec_result:
+                    operations = spec_result.get("operations", [])
+                    console.print(
+                        f"  [green]\u2713[/green] OpenAPI spec: {len(operations)} operations"
+                    )
+                    summary_parts = [spec_result.get("description", "API-based agent")]
+                    for op in operations:
+                        summary_parts.append(
+                            f"- {op.get('method', 'GET')} {op.get('path', '')}: {op.get('summary', '')}"
+                        )
+                    text_parts.append("\n".join(summary_parts))
+                else:
+                    console.print("  [yellow]![/yellow] OpenAPI spec: could not parse")
+
+            # --endpoint -> endpoint source (API probing)
+            if endpoint:
+                bot_config = _load_integration(endpoint)
+                chat_ep = bot_config.get("chat_completion", {}).get("endpoint", "")
+                console.print(
+                    f"  [green]\u2713[/green] Endpoint source: [dim]{chat_ep or '(from config)'}[/dim]"
+                )
+                sources.append({"source": "endpoint", "data": bot_config})
+
+            # Merge accumulated text parts into a single text source
+            if text_parts:
+                merged_text = "\n\n---\n\n".join(text_parts)
+                sources.append({"source": "text", "data": {"text": merged_text}})
 
         if not sources:
             console.print("[red]No valid sources could be built from provided flags.[/red]")
@@ -519,8 +660,18 @@ def _connect_agent_platform(
         console.print(f"  [green]\u2713[/green] Scan complete [dim]({scan_duration:.1f}s)[/dim]\n")
 
         # -- Display results ---------------------------------------------------
-        scope = response.get("scope", {})
+        analyzed_scope = response.get("scope", {})
         risk_profile = response.get("risk_profile", {})
+
+        if user_scope:
+            # --scope path: diff, propose, merge.
+            additions = _diff_scope(user_scope, analyzed_scope)
+            accept = _confirm_scope_additions(additions, auto_yes=yes)
+            scope = _merge_scope(
+                user_scope, additions if accept else {"permitted": [], "restricted": []}
+            )
+        else:
+            scope = analyzed_scope
 
         _display_scope(scope)
 
@@ -549,7 +700,9 @@ def _connect_agent_platform(
                 "scope": scope,
             }
 
-            default_integration = response.get("default_integration")
+            # When --scope + --endpoint, integration comes from the local load
+            # since we deliberately didn't send endpoint as a /scan source.
+            default_integration = local_integration or response.get("default_integration")
             if default_integration:
                 project_data["default_integration"] = default_integration
 
@@ -573,13 +726,32 @@ def _connect_agent_platform(
         )
 
         # -- Auto-test ---------------------------------------------------------
-        _auto_test(client, project_id, default_integration, context, level)
+        if no_test:
+            console.print()
+            console.print("[dim]Skipping auto-test (--no-test).[/dim]")
+        else:
+            _auto_test(
+                client,
+                project_id,
+                default_integration,
+                context,
+                level,
+                test_category=resolved_category,
+            )
 
         # -- Continuous monitoring recommendation ------------------------------
         _recommend_monitoring(risk_profile)
 
         # -- Next suggestions --------------------------------------------------
-        _print_next(
+        next_suggestions = []
+        if no_test:
+            if test_category_arg:
+                next_suggestions.append(
+                    (f"hb test --test-category {test_category_arg}", "Run the first security test")
+                )
+            else:
+                next_suggestions.append(("hb test", "Run the first security test"))
+        next_suggestions.extend(
             [
                 ("hb findings", "Detailed breakdown"),
                 ("hb test --deep", "Deeper analysis"),
@@ -587,6 +759,7 @@ def _connect_agent_platform(
                 ("hb report", "Share with team"),
             ]
         )
+        _print_next(next_suggestions)
 
     except NotAuthenticatedError:
         telemetry.fire_gated_command_hit()
@@ -695,6 +868,158 @@ def _connect_agent_local(endpoint, name, prompt, repo, openapi, context, level, 
     )
 
 
+def _load_scope_file(path: str) -> dict:
+    """Parse + validate a user-supplied scope YAML/JSON file.
+
+    Returns a dict with keys: business_scope, permitted, restricted, more_info.
+    Raises FileNotFoundError if missing, ValueError with a message naming the
+    offending key on shape violations.
+    """
+    import yaml
+
+    file_path = Path(path)
+    if not file_path.is_file():
+        raise FileNotFoundError(f"--scope file not found: {path}")
+
+    raw = file_path.read_text()
+    ext = file_path.suffix.lower()
+    try:
+        if ext == ".json":
+            data = json.loads(raw)
+        elif ext in (".yaml", ".yml"):
+            data = yaml.safe_load(raw)
+        else:
+            try:
+                data = yaml.safe_load(raw)
+            except yaml.YAMLError:
+                data = json.loads(raw)
+    except (yaml.YAMLError, json.JSONDecodeError) as e:
+        raise ValueError(f"--scope: could not parse {path}: {e}")
+
+    if not isinstance(data, dict):
+        raise ValueError(f"--scope: top-level must be a mapping; got {type(data).__name__}")
+
+    business_scope = data.get("business_scope")
+    if not isinstance(business_scope, str) or not business_scope.strip():
+        raise ValueError("--scope: 'business_scope' must be a non-empty string")
+
+    permitted = data.get("permitted")
+    if not isinstance(permitted, list) or not permitted:
+        raise ValueError("--scope: 'permitted' must be a non-empty list")
+    if not all(isinstance(p, str) and p.strip() for p in permitted):
+        raise ValueError("--scope: 'permitted' must contain non-empty strings")
+
+    restricted = data.get("restricted")
+    if not isinstance(restricted, list) or not restricted:
+        raise ValueError("--scope: 'restricted' must be a non-empty list")
+    if not all(isinstance(r, str) and r.strip() for r in restricted):
+        raise ValueError("--scope: 'restricted' must contain non-empty strings")
+
+    more_info = data.get("more_info", "")
+    if more_info is None:
+        more_info = ""
+    if not isinstance(more_info, str):
+        raise ValueError("--scope: 'more_info' must be a string when present")
+
+    return {
+        "business_scope": business_scope,
+        "permitted": permitted,
+        "restricted": restricted,
+        "more_info": more_info,
+    }
+
+
+def _serialize_scope_to_text(scope: dict) -> str:
+    """Render a parsed scope dict into the text blob sent as a /scan 'text' source."""
+    lines = [f"Business scope: {scope['business_scope']}", ""]
+    lines.append("Permitted intents:")
+    for p in scope["permitted"]:
+        lines.append(f"- {p}")
+    lines.append("")
+    lines.append("Restricted intents:")
+    for r in scope["restricted"]:
+        lines.append(f"- {r}")
+    more_info = scope.get("more_info", "").strip()
+    if more_info:
+        lines.append("")
+        lines.append(f"Additional context: {more_info}")
+    return "\n".join(lines)
+
+
+def _diff_scope(user_scope: dict, analyzed_scope: dict) -> dict:
+    """Return additive proposals — items in analyzed but not in user.
+
+    Comparison is case-insensitive after trimming whitespace.
+    Never proposes removals; user's intents are always preserved.
+    """
+
+    def _norm(s: str) -> str:
+        return s.strip().lower()
+
+    user_permitted_norm = {_norm(p) for p in user_scope.get("permitted", [])}
+    user_restricted_norm = {_norm(r) for r in user_scope.get("restricted", [])}
+
+    intents = analyzed_scope.get("intents", {}) if isinstance(analyzed_scope, dict) else {}
+    analyzed_permitted = intents.get("permitted", []) or []
+    analyzed_restricted = intents.get("restricted", []) or []
+
+    return {
+        "permitted": [p for p in analyzed_permitted if _norm(p) not in user_permitted_norm],
+        "restricted": [r for r in analyzed_restricted if _norm(r) not in user_restricted_norm],
+    }
+
+
+def _merge_scope(user_scope: dict, additions: dict) -> dict:
+    """Return a scope dict in /scan response shape, merging accepted additions."""
+    return {
+        "overall_business_scope": user_scope["business_scope"],
+        "intents": {
+            "permitted": list(user_scope["permitted"]) + list(additions.get("permitted", [])),
+            "restricted": list(user_scope["restricted"]) + list(additions.get("restricted", [])),
+        },
+        "more_info": user_scope.get("more_info", ""),
+    }
+
+
+def _confirm_scope_additions(additions: dict, auto_yes: bool) -> bool:
+    """Render the proposal panel and prompt for Y/N. Returns True to accept additions."""
+    permitted = additions.get("permitted", [])
+    restricted = additions.get("restricted", [])
+
+    if not permitted and not restricted:
+        console.print()
+        console.print("[dim]Your scope looks complete — no additions proposed.[/dim]")
+        return False
+
+    parts = ["We analysed your scope and noticed these additional intents:", ""]
+    if permitted:
+        parts.append("[bold green]Permitted (proposed):[/bold green]")
+        for p in permitted:
+            parts.append(f"  [green]+[/green] {p}")
+    if restricted:
+        if permitted:
+            parts.append("")
+        parts.append("[bold red]Restricted (proposed):[/bold red]")
+        for r in restricted:
+            parts.append(f"  [red]+[/red] {r}")
+
+    console.print()
+    console.print(
+        Panel(
+            "\n".join(parts),
+            title="Scope analysis",
+            border_style="blue",
+        )
+    )
+
+    if auto_yes:
+        return True
+
+    from rich.prompt import Confirm
+
+    return Confirm.ask("\nAccept these additions?", default=True)
+
+
 def _write_scope_yaml(scope: dict, path: Path):
     """Serialize scope dict to a .yaml file in the canonical template shape."""
     try:
@@ -799,7 +1124,14 @@ def _build_monitoring_message(risk_level: str, matching_regs: list) -> str:
 # -- Auto-test helper ----------------------------------------------------------
 
 
-def _auto_test(client, project_id, default_integration, context=None, level="unit"):
+def _auto_test(
+    client,
+    project_id,
+    default_integration,
+    context=None,
+    level="unit",
+    test_category=DEFAULT_TEST_CATEGORY,
+):
     """Run first test automatically and show results inline."""
     if not default_integration:
         console.print("\n[dim]No agent integration configured -- skipping auto-test.[/dim]")
@@ -838,7 +1170,7 @@ def _auto_test(client, project_id, default_integration, context=None, level="uni
         experiment_data = {
             "name": f"connect-{time.strftime('%Y%m%d-%H%M%S')}",
             "description": "Initial assessment from hb connect",
-            "test_category": "humanbound/adversarial/owasp_agentic",
+            "test_category": test_category,
             "testing_level": level,
             "provider_id": provider_id,
             "auto_start": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.0.4"
+version = "2.0.5"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -11,6 +11,7 @@ ship unnoticed.
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 from conftest import MOCK_PROVIDER, assert_exit_ok
 
@@ -18,6 +19,36 @@ from humanbound_cli.main import cli
 
 PATCH_CLIENT = "humanbound_cli.commands.connect.HumanboundClient"
 runner = CliRunner()
+
+
+def _write_scope_yaml(tmp_path, **overrides):
+    """Write a minimal valid scope.yaml under tmp_path; return its str path.
+
+    Default contents match the canonical scope shape; pass keyword args to
+    override individual top-level keys.
+    """
+    import yaml
+
+    doc = {
+        "business_scope": (
+            "Customer support agent for an online retailer. Handles order status, "
+            "returns, and product questions."
+        ),
+        "permitted": [
+            "Look up order status for the authenticated customer",
+            "Initiate a return for an in-policy order",
+            "Answer product specification questions",
+        ],
+        "restricted": [
+            "Quote a refund amount before the return is inspected",
+            "Disclose another customer's order details",
+        ],
+        "more_info": "Agent uses a vector store of product manuals.",
+    }
+    doc.update(overrides)
+    path = tmp_path / "scope.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return str(path)
 
 
 def _make_authenticated_client(**overrides):
@@ -74,7 +105,16 @@ class TestHelpSurface:
     def test_flag_surface_stable(self, MockCls):
         """Lock down the flags we publicly document."""
         result = runner.invoke(cli, ["connect", "--help"])
-        for flag in ("--name", "--level", "--yes", "--context", "--endpoint"):
+        for flag in (
+            "--name",
+            "--level",
+            "--yes",
+            "--context",
+            "--endpoint",
+            "--no-test",
+            "--test-category",
+            "--scope",
+        ):
             assert flag in result.output, f"missing flag: {flag}"
 
     @patch(PATCH_CLIENT)
@@ -279,3 +319,618 @@ class TestRegressionGuards:
         # Bundled templates must be shippable
         for domain in ("banking", "insurance", "healthcare", "legal", "ecommerce", "eu-ai-act"):
             assert compliance.load_template(domain), f"missing template: {domain}"
+
+
+# ---------------------------------------------------------------------------
+# Helper: _load_scope_file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadScopeFile:
+    def test_loads_valid_yaml(self, tmp_path):
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        scope = _load_scope_file(_write_scope_yaml(tmp_path))
+        assert scope["business_scope"].startswith("Customer support agent")
+        assert len(scope["permitted"]) == 3
+        assert len(scope["restricted"]) == 2
+        assert "vector store" in scope["more_info"]
+
+    def test_loads_valid_json(self, tmp_path):
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        p = tmp_path / "scope.json"
+        p.write_text('{"business_scope":"X","permitted":["a"],"restricted":["b"]}')
+        scope = _load_scope_file(str(p))
+        assert scope["business_scope"] == "X"
+        assert scope["permitted"] == ["a"]
+        assert scope["restricted"] == ["b"]
+        assert scope.get("more_info", "") == ""
+
+    def test_missing_permitted_raises(self, tmp_path):
+        import yaml
+
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        # Build a file with no `permitted` key.
+        bad = tmp_path / "scope.yaml"
+        bad.write_text(
+            yaml.safe_dump(
+                {
+                    "business_scope": "X",
+                    "restricted": ["r"],
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="permitted"):
+            _load_scope_file(str(bad))
+
+    def test_empty_business_scope_raises(self, tmp_path):
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        p = tmp_path / "scope.yaml"
+        p.write_text("business_scope: ''\npermitted: [a]\nrestricted: [b]\n")
+        with pytest.raises(ValueError, match="business_scope"):
+            _load_scope_file(str(p))
+
+    def test_permitted_non_list_raises(self, tmp_path):
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        p = tmp_path / "scope.yaml"
+        p.write_text("business_scope: 'X'\npermitted: 'not-a-list'\nrestricted: [b]\n")
+        with pytest.raises(ValueError, match="permitted"):
+            _load_scope_file(str(p))
+
+    def test_unreadable_file_raises(self, tmp_path):
+        from humanbound_cli.commands.connect import _load_scope_file
+
+        with pytest.raises(FileNotFoundError):
+            _load_scope_file(str(tmp_path / "does_not_exist.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# Helper: _serialize_scope_to_text
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeScopeToText:
+    def test_basic_render(self):
+        from humanbound_cli.commands.connect import _serialize_scope_to_text
+
+        text = _serialize_scope_to_text(
+            {
+                "business_scope": "X agent",
+                "permitted": ["p1", "p2"],
+                "restricted": ["r1"],
+                "more_info": "extra",
+            }
+        )
+        assert "Business scope: X agent" in text
+        assert "Permitted intents:" in text
+        assert "- p1" in text
+        assert "- p2" in text
+        assert "Restricted intents:" in text
+        assert "- r1" in text
+        assert "Additional context: extra" in text
+
+    def test_empty_more_info_omits_section(self):
+        from humanbound_cli.commands.connect import _serialize_scope_to_text
+
+        text = _serialize_scope_to_text(
+            {
+                "business_scope": "X",
+                "permitted": ["p"],
+                "restricted": ["r"],
+                "more_info": "",
+            }
+        )
+        assert "Additional context" not in text
+
+    def test_clears_min_length_threshold(self):
+        from humanbound_cli.commands.connect import _serialize_scope_to_text
+
+        # BE's TextSourceData enforces >= 10 chars after strip()
+        text = _serialize_scope_to_text(
+            {
+                "business_scope": "X",
+                "permitted": ["p"],
+                "restricted": ["r"],
+                "more_info": "",
+            }
+        )
+        assert len(text.strip()) >= 10
+
+
+# ---------------------------------------------------------------------------
+# Helper: _diff_scope
+# ---------------------------------------------------------------------------
+
+
+class TestDiffScope:
+    def test_returns_only_new_items(self):
+        from humanbound_cli.commands.connect import _diff_scope
+
+        user = {"permitted": ["a", "b"], "restricted": ["x"]}
+        analyzed = {
+            "intents": {
+                "permitted": ["a", "b", "c"],
+                "restricted": ["x", "y"],
+            }
+        }
+        diff = _diff_scope(user, analyzed)
+        assert diff["permitted"] == ["c"]
+        assert diff["restricted"] == ["y"]
+
+    def test_no_additions_returns_empty_lists(self):
+        from humanbound_cli.commands.connect import _diff_scope
+
+        user = {"permitted": ["a"], "restricted": ["x"]}
+        analyzed = {"intents": {"permitted": ["a"], "restricted": ["x"]}}
+        diff = _diff_scope(user, analyzed)
+        assert diff == {"permitted": [], "restricted": []}
+
+    def test_normalises_case_and_whitespace(self):
+        from humanbound_cli.commands.connect import _diff_scope
+
+        user = {"permitted": ["  Look Up Orders  "], "restricted": ["X"]}
+        analyzed = {"intents": {"permitted": ["look up orders"], "restricted": ["x"]}}
+        diff = _diff_scope(user, analyzed)
+        assert diff == {"permitted": [], "restricted": []}
+
+    def test_handles_missing_analyzed_intents(self):
+        from humanbound_cli.commands.connect import _diff_scope
+
+        user = {"permitted": ["a"], "restricted": ["b"]}
+        analyzed = {}  # malformed /scan response
+        diff = _diff_scope(user, analyzed)
+        assert diff == {"permitted": [], "restricted": []}
+
+
+# ---------------------------------------------------------------------------
+# --no-test flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoTestFlag:
+    @patch(PATCH_CLIENT)
+    def test_no_test_skips_auto_test(self, MockCls):
+        """--no-test → project still created, but _auto_test is not called."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "tech"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._auto_test") as mock_auto_test:
+            result = runner.invoke(
+                cli,
+                ["connect", "--endpoint", endpoint_json, "--yes", "--no-test"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_auto_test.assert_not_called()
+        # Project IS created
+        project_calls = [c for c in client.post.call_args_list if c.args[0] == "projects"]
+        assert project_calls, "project should still be created"
+
+    @patch(PATCH_CLIENT)
+    def test_no_test_hint_omits_category_when_default(self, MockCls):
+        """--no-test without --test-category → Next-hint shows plain 'hb test'."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "tech"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._auto_test"):
+            result = runner.invoke(
+                cli,
+                ["connect", "--endpoint", endpoint_json, "--yes", "--no-test"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Plain `hb test` appears; no --test-category in the hint
+        assert "hb test" in result.output
+        assert "hb test --test-category" not in result.output
+
+    @patch(PATCH_CLIENT)
+    def test_no_test_hint_includes_category_when_passed(self, MockCls):
+        """--no-test --test-category <path> → Next-hint includes the path the user passed."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "tech"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._auto_test"):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--endpoint",
+                    endpoint_json,
+                    "--yes",
+                    "--no-test",
+                    "--test-category",
+                    "humanbound/adversarial/owasp_single_turn",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # The Next-hint surfaces the user's choice (note: warning above also mentions it)
+        assert "hb test --test-category humanbound/adversarial/owasp_single_turn" in result.output
+
+    @patch(PATCH_CLIENT)
+    def test_no_test_plus_category_warns(self, MockCls):
+        """--no-test + --test-category should print a warning and continue."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "tech"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._auto_test"):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--endpoint",
+                    endpoint_json,
+                    "--yes",
+                    "--no-test",
+                    "--test-category",
+                    "humanbound/adversarial/owasp_single_turn",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "--test-category is ignored when --no-test is set" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --test-category resolution via the CLI
+# ---------------------------------------------------------------------------
+
+
+class TestTestCategoryCli:
+    @patch(PATCH_CLIENT)
+    def test_alias_single_reaches_experiment_payload(self, MockCls):
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "tech"},
+                "default_integration": {"chat_completion": {"endpoint": "https://x"}},
+            }
+            if path == "scan"
+            else ({"id": "exp-1"} if path == "experiments" else {"id": "proj-new"})
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._recommend_monitoring"):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--endpoint",
+                    endpoint_json,
+                    "--yes",
+                    "--test-category",
+                    "humanbound/adversarial/owasp_single_turn",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        exp_calls = [c for c in client.post.call_args_list if c.args[0] == "experiments"]
+        assert exp_calls, "expected POST /experiments"
+        payload = exp_calls[0].kwargs.get("data") or exp_calls[0].args[1]
+        assert payload["test_category"] == "humanbound/adversarial/owasp_single_turn"
+
+
+# ---------------------------------------------------------------------------
+# --scope flag
+# ---------------------------------------------------------------------------
+
+
+class TestScopeFlag:
+    @patch(PATCH_CLIENT)
+    def test_scope_only_sends_text_source(self, MockCls, tmp_path):
+        """--scope alone → /scan called with a single text source, project created."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Customer support agent",
+                    "intents": {
+                        "permitted": [
+                            "Look up order status for the authenticated customer",
+                        ],
+                        "restricted": [
+                            "Quote a refund amount before the return is inspected",
+                        ],
+                    },
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "retail"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        with (
+            patch("humanbound_cli.commands.connect._auto_test"),
+            patch("humanbound_cli.commands.connect._recommend_monitoring"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["connect", "--scope", _write_scope_yaml(tmp_path), "--yes"],
+            )
+
+        assert result.exit_code == 0, result.output
+        scan_calls = [c for c in client.post.call_args_list if c.args[0] == "scan"]
+        assert scan_calls, "POST /scan should have been invoked"
+        scan_payload = scan_calls[0].kwargs.get("data") or scan_calls[0].args[1]
+        sources = scan_payload["sources"]
+        assert len(sources) == 1
+        assert sources[0]["source"] == "text"
+        # The text source must include the user's business scope
+        assert "Customer support agent" in sources[0]["data"]["text"]
+
+    @patch(PATCH_CLIENT)
+    def test_scope_with_endpoint_excludes_endpoint_source(self, MockCls, tmp_path):
+        """--scope + --endpoint → /scan still text-only; default_integration set locally."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Customer support agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "retail"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with (
+            patch("humanbound_cli.commands.connect._auto_test"),
+            patch("humanbound_cli.commands.connect._recommend_monitoring"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--scope",
+                    _write_scope_yaml(tmp_path),
+                    "--endpoint",
+                    endpoint_json,
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        scan_calls = [c for c in client.post.call_args_list if c.args[0] == "scan"]
+        scan_payload = scan_calls[0].kwargs.get("data") or scan_calls[0].args[1]
+        sources = scan_payload["sources"]
+        source_types = [s["source"] for s in sources]
+        assert source_types == ["text"], f"expected ['text'], got {source_types}"
+
+        # Project payload should carry default_integration from --endpoint
+        project_calls = [c for c in client.post.call_args_list if c.args[0] == "projects"]
+        proj_payload = project_calls[0].kwargs.get("data") or project_calls[0].args[1]
+        assert (
+            proj_payload["default_integration"]["chat_completion"]["endpoint"]
+            == "https://bot.example.com"
+        )
+
+    @patch(PATCH_CLIENT)
+    def test_scope_proposals_displayed_and_merged(self, MockCls, tmp_path):
+        """When /scan returns additional intents, they're displayed and merged on accept."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "ignored",
+                    "intents": {
+                        # Adds one extra permitted, one extra restricted
+                        "permitted": [
+                            "Look up order status for the authenticated customer",
+                            "Generate weekly summary reports",
+                        ],
+                        "restricted": [
+                            "Quote a refund amount before the return is inspected",
+                            "Disclose internal pricing models",
+                        ],
+                    },
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "retail"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        with (
+            patch("humanbound_cli.commands.connect._auto_test"),
+            patch("humanbound_cli.commands.connect._recommend_monitoring"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["connect", "--scope", _write_scope_yaml(tmp_path), "--yes"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Proposal panel appears
+        assert "Generate weekly summary reports" in result.output
+        assert "Disclose internal pricing models" in result.output
+
+        # Merged scope arrives at /projects: user's items + accepted additions
+        project_calls = [c for c in client.post.call_args_list if c.args[0] == "projects"]
+        proj_payload = project_calls[0].kwargs.get("data") or project_calls[0].args[1]
+        permitted = proj_payload["scope"]["intents"]["permitted"]
+        restricted = proj_payload["scope"]["intents"]["restricted"]
+        assert "Look up order status for the authenticated customer" in permitted
+        assert "Generate weekly summary reports" in permitted
+        assert "Disclose internal pricing models" in restricted
+        # User's business_scope wins (from the helper-built scope)
+        assert proj_payload["scope"]["overall_business_scope"].startswith(
+            "Customer support agent for an online retailer"
+        )
+
+    @patch(PATCH_CLIENT)
+    def test_scope_bad_file_exits_with_error(self, MockCls, tmp_path):
+        """A scope file missing 'permitted' exits with code 1 and a clear message."""
+        import yaml
+
+        MockCls.return_value = _make_authenticated_client()
+        bad = tmp_path / "scope.yaml"
+        bad.write_text(
+            yaml.safe_dump(
+                {
+                    "business_scope": "X",
+                    "restricted": ["r"],
+                }
+            )
+        )
+        result = runner.invoke(
+            cli,
+            ["connect", "--scope", str(bad), "--yes"],
+        )
+        assert result.exit_code != 0
+        assert "permitted" in result.output.lower()
+
+    @patch(PATCH_CLIENT)
+    def test_scope_plus_prompt_warns(self, MockCls, tmp_path):
+        """--scope + --prompt → warning printed, --prompt ignored, flow proceeds."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "x",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "x"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        scope_file = _write_scope_yaml(tmp_path)
+        with (
+            patch("humanbound_cli.commands.connect._auto_test"),
+            patch("humanbound_cli.commands.connect._recommend_monitoring"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--scope",
+                    scope_file,
+                    "--prompt",
+                    scope_file,
+                    "--yes",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "--prompt" in result.output and "ignored" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# init telemetry payload
+# ---------------------------------------------------------------------------
+
+
+class TestInitTelemetry:
+    @patch(PATCH_CLIENT)
+    @patch("humanbound_cli.commands.connect.telemetry.capture")
+    def test_init_event_includes_new_fields(self, mock_capture, MockCls):
+        """init telemetry event should carry test_category, no_test, scope_provided."""
+        client = _make_authenticated_client()
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Test agent",
+                    "intents": {"permitted": ["p"], "restricted": ["r"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "x"},
+                "default_integration": None,
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        endpoint_json = '{"chat_completion":{"endpoint":"https://bot.example.com"}}'
+        with patch("humanbound_cli.commands.connect._auto_test"):
+            result = runner.invoke(
+                cli,
+                [
+                    "connect",
+                    "--endpoint",
+                    endpoint_json,
+                    "--yes",
+                    "--no-test",
+                    "--test-category",
+                    "humanbound/adversarial/owasp_single_turn",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        init_calls = [c for c in mock_capture.call_args_list if c.args[0] == "init"]
+        assert init_calls, "init telemetry event should fire"
+        payload = init_calls[0].args[1]
+        assert payload["no_test"] is True
+        assert payload["test_category"] == "humanbound/adversarial/owasp_single_turn"
+        assert payload["scope_provided"] is False

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -539,7 +539,17 @@ def test_connect_fire_init_helper_emits_event(monkeypatch):
     connect_module._fire_init_event(mode="endpoint", success=True, duration_ms=123)
 
     assert calls == [
-        ("init", {"mode": "endpoint", "success": True, "duration_ms": 123}),
+        (
+            "init",
+            {
+                "mode": "endpoint",
+                "success": True,
+                "duration_ms": 123,
+                "no_test": False,
+                "test_category": "humanbound/adversarial/owasp_agentic",
+                "scope_provided": False,
+            },
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary

  Adds three new flags to `hb connect` to give users finer control over the
  auto-test step and an alternative way to seed scope discovery:

  - **`--no-test`** creates the project and renders the dashboard but skips the auto-test step. The "Next" hints adjust to surface `hb test` for running it later.
  - **`--test-category`** chooses which test family the auto-test launches (default: `humanbound/adversarial/owasp_agentic`). Mirrors the same flag on `hb test`. Ignored — with a yellow warn-and-continue notice — when `--no-test` is also set.
  - **`--scope ./scope.yaml`** loads a pre-made scope file (YAML or JSON) as input. Sent to `POST /scan` as a `text` source only, so no agent probing happens. The backend analyser returns its own derived scope; the CLI diffs it against the user's file and prompts for accept/decline of additive `permitted` / `restricted` intents before project creation (`--yes` auto-accepts). `--prompt`/`--repo`/`--openapi` are ignored when `--scope` is set (warn-and-continue); `--endpoint` is still honoured for `default_integration` but is never sent as a scan source.

  Backwards-compatible: existing flag combinations behave unchanged. The
  existing `_auto_test` helper was parameterised to accept a `test_category`
  kwarg (default = today's hardcoded value, so no behaviour change for
  callers that don't set it). Init telemetry payload extended with
  `no_test`, `test_category`, and `scope_provided` fields.

  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [x] New feature (non-breaking)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation only
  - [ ] Build / tooling / CI

  ## Checklist

  - [x] Tests added for new behavior / regression covered for a bug fix
  - [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
  - [x] `CHANGELOG.md` updated under `[Unreleased]`
  - [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
  - [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

  ## Linked issue(s)
