### PR TITLE
feat(engine): add SSE streaming + permissive content extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `resp`, `answer`, `ans`, `message`, `reply`, `output`.
 
 ### Changed
-- **Breaking: `streaming` in agent config is no longer a boolean.** Use
-  `null` (REST, default), `"websocket"`, or `"sse"`. Configs with
-  `"streaming": false` should migrate to `null` or omit the field.
+- **Breaking: `streaming` in agent config is now an enum.** Use `null`
+  (REST, default), `"websocket"`, or `"sse"`. Configs with the legacy
+  boolean form (`"streaming": true` / `false`) are no longer accepted by
+  the engine — migrate `false` to `null` (or omit the field) and `true`
+  to `"websocket"`.
 
 ### Fixed
 - **WebSocket streaming filter** previously always returned `False` due to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Server-Sent Events (SSE) as a third chat-completion transport.** Set
+  `"streaming": "sse"` in the agent config; the engine reads `data:`-line
+  frames until `{"type":"end"}` or connection close.
+- **Permissive content extraction.** The engine now walks the response JSON
+  recursively for any known content key — customers can send native vendor
+  shapes (OpenAI, Anthropic, RAG-style) without wrapping their bot's
+  response. Extended set of recognized keys: `content`, `text`, `response`,
+  `resp`, `answer`, `ans`, `message`, `reply`, `output`.
+
+### Changed
+- **Breaking: `streaming` in agent config is no longer a boolean.** Use
+  `null` (REST, default), `"websocket"`, or `"sse"`. Configs with
+  `"streaming": false` should migrate to `null` or omit the field.
+
+### Fixed
+- **WebSocket streaming filter** previously always returned `False` due to a
+  dict-vs-list comparison bug, causing the engine to rely on the fallback
+  extractor for every chunk.
+
 ## [2.0.5] — 2026-06-05
 
 ### Fixed

--- a/docs/docs/getting-started/agent-config.md
+++ b/docs/docs/getting-started/agent-config.md
@@ -19,7 +19,7 @@ The `--endpoint / -e` flag on `hb connect` accepts a JSON config file (or inline
 
 ```json
 {
-  "streaming": false,
+  "streaming": null,
   "thread_auth": {
     "endpoint": "",
     "headers": {},
@@ -55,11 +55,11 @@ The `--endpoint / -e` flag on `hb connect` accepts a JSON config file (or inline
 - **`thread_init`** (required) -- Thread or session creation endpoint, called once per conversation before sending messages.
 - **`thread_auth`** (optional) -- For agents that require authentication (e.g., OAuth token exchange) before testing can begin.
 - **`$PROMPT`** -- The placeholder in the payload that gets replaced with each test prompt at runtime.
-- **`streaming`** -- Set to `true` for WebSocket/SSE streaming endpoints.
+- **`streaming`** -- Transport: `null` (REST, default), `"websocket"`, or `"sse"`. Leave `null` if your agent returns a single JSON response per request.
 - **`telemetry`** (optional) -- Enables white-box agentic testing by collecting tool calls, memory operations, and resource usage from your observability platform. See [Telemetry](#telemetry-optional) below.
 
 !!! info "Note"
-    At minimum, you must provide `chat_completion` and `thread_init`. `headers` and `payload` fields are required in each section but can be empty objects if not needed. Use them to pass API keys, content types, or other metadata as needed by your agent. If no `"$PROMPT"` placeholder is found in the payload, Humanbound will append the prompt to the end of the payload by default assuming OpenAI-style input. The agent output should be in the response body of the `chat_completion` endpoint for Humanbound to capture it for analysis. The expected response format is a JSON object with any of `content | ans | answer | response | resp` field containing the agent's reply.
+    At minimum, you must provide `chat_completion` and `thread_init`. `headers` and `payload` fields are required in each section but can be empty objects if not needed. Use them to pass API keys, content types, or other metadata as needed by your agent. If no `"$PROMPT"` placeholder is found in the payload, Humanbound will append the prompt to the end of the payload by default assuming OpenAI-style input. The agent output should be in the response body of the `chat_completion` endpoint for Humanbound to capture it for analysis. The expected response format is a JSON object with any of `content | text | response | resp | answer | ans | message | reply | output` field containing the agent's reply (Humanbound walks the response recursively, so the field can be nested).
 
 ## Basic Example
 
@@ -84,7 +84,7 @@ The `--endpoint / -e` flag on `hb connect` accepts a JSON config file (or inline
 
 ```json
 {
-  "streaming": false,
+  "streaming": null,
   "thread_auth": {
     "endpoint": "https://agent.com/oauth/token",
     "headers": {},

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -48,7 +48,7 @@ Create a `bot-config.json` describing how to talk to your agent:
 
 ```json
 {
-  "streaming": false,
+  "streaming": null,
   "thread_auth": {"endpoint": "", "headers": {}, "payload": {}},
   "thread_init": {
     "endpoint": "https://your-bot.com/sessions",

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -128,7 +128,7 @@ Create a JSON file that tells Humanbound how to talk to your agent. The `$PROMPT
 
 ```json
 {
-  "streaming": false,
+  "streaming": null,
   "thread_auth": {
     "endpoint": "https://your-bot.com/oauth/token",
     "headers": {},
@@ -160,7 +160,7 @@ Create a JSON file that tells Humanbound how to talk to your agent. The `$PROMPT
 | `chat_completion` | Yes | The endpoint your agent listens on for chat messages. Use `$PROMPT` in the payload where user input goes. |
 | `thread_auth` | No | OAuth/token endpoint called before testing begins. The response payload (`access_token`, `refresh_token`, etc.) is captured and injected into subsequent requests. |
 | `thread_init` | Yes | Session/thread creation endpoint. Called once per conversation to initialize a thread before sending chat messages. |
-| `streaming` | No | Set `true` if your agent uses WebSocket/SSE streaming. |
+| `streaming` | No | Transport: `null` (REST, default), `"websocket"`, or `"sse"`. |
 
 !!! info "Minimal config"
     `chat_completion` and `thread_init` are required. Skip `thread_auth` if your agent uses simple API key auth and doesn't need OAuth.

--- a/docs/docs/integrations/telemetry.md
+++ b/docs/docs/integrations/telemetry.md
@@ -34,7 +34,7 @@ The `telemetry` object sits inside your agent config JSON, alongside `chat_compl
 
 ```json
 {
-  "streaming": false,
+  "streaming": null,
   "thread_init": { "..." },
   "chat_completion": { "..." },
   "telemetry": {

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -124,7 +124,7 @@ def _load_integration(value: str) -> dict:
         console.print("[red]--endpoint must be a JSON string or path to a JSON file.[/red]")
         console.print("[dim]Example: --endpoint ./bot-config.json[/dim]")
         console.print(
-            '[dim]Example: --endpoint \'{"streaming": false, "chat_completion": {"endpoint": "...", "headers": {}, "payload": {"content": "$PROMPT"}}}\'[/dim]'
+            '[dim]Example: --endpoint \'{"streaming": null, "chat_completion": {"endpoint": "...", "headers": {}, "payload": {"content": "$PROMPT"}}}\'[/dim]'
         )
         raise SystemExit(1)
 

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -10,6 +10,7 @@ import time
 import traceback
 
 import certifi
+import httpx
 import requests
 
 logger = logging.getLogger("humanbound.engine.bot")
@@ -23,7 +24,20 @@ def _log_error(title="", description=None, tag="", hook=""):
 MIN_URL_LENGTH = 80  # truncate url after this character
 REQUESTS_TIMEOUT = 500
 
-DEFAULT_AI_RESPONSE_KEYS = ["content", "text", "response", "resp", "answer", "ans"]
+DEFAULT_AI_RESPONSE_KEYS = [
+    "content",
+    "text",
+    "response",
+    "resp",
+    "answer",
+    "ans",
+    "message",
+    "reply",
+    "output",
+]
+
+# Browser-like UA — WAFs 302-challenge burst traffic from the python-httpx UA.
+SSE_DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; Humanbound-AI-Test/1.0)"
 
 ssl_context = ssl.create_default_context()
 ssl_context.load_verify_locations(certifi.where())
@@ -62,40 +76,46 @@ class Bot(ResponseExtractor):
         self.bot_config = bot_config
         self.e_id = e_id
 
-    #
-    # Utility functions
-    #
-
-    # Utility functions to handle the ai agent's response from the chunked websocket message
-    # or the http api call -> extract the actual response from the chunk
-    # IMPORTANT: Handle also conversational UI elements (e.g. quick replies, buttons, etc.)
-    # => convert them to text that guides the conversation so as the test/atatck agent
-    # can understand and use them in the next prompt (LLM response genetrator)
-
-    # for streaming responses, identify if the chunck holds a response delta (for streaming cases)
-    def __is_ai_response_chunk(self, chunk):
-        if "type" not in chunk:
-            return False
-        if chunk["type"] != "chunk":
-            return False
-        if chunk not in DEFAULT_AI_RESPONSE_KEYS:
-            return False
-        return True
-
-    # extract the AI agent's response from the API response
-    def __extract_ai_response(self, chunk):
-        if isinstance(chunk, dict):
-            # Basic extraction logic -> check for the various common response formats
+    # Recursively find the first known content key whose value is a string.
+    def __find_content(self, obj):
+        if isinstance(obj, dict):
             for key in DEFAULT_AI_RESPONSE_KEYS:
-                if key in chunk and isinstance(chunk[key], str):
-                    return chunk[key]
+                if isinstance(obj.get(key), str):
+                    return obj[key]
+            for v in obj.values():
+                found = self.__find_content(v)
+                if found is not None:
+                    return found
+        elif isinstance(obj, list):
+            for v in obj:
+                found = self.__find_content(v)
+                if found is not None:
+                    return found
+        return None
 
-            # Try custom extraction for non-standard formats
-            custom = self.extract_custom_response(chunk)
-            if custom:
-                return custom
+    def __is_ai_response_chunk(self, chunk):
+        return isinstance(chunk, dict) and self.__find_content(chunk) is not None
 
+    def __extract_ai_response(self, chunk):
+        if not isinstance(chunk, dict):
+            return str(chunk)
+        found = self.__find_content(chunk)
+        if found is not None:
+            return found
+        custom = self.extract_custom_response(chunk)
+        if custom:
+            return custom
         return str(chunk)
+
+    # Shared by __listen (WS) and __stream_sse (SSE). {"type":"end"} stops the stream.
+    def __process_chunk(self, chunk, buffer):
+        if not isinstance(chunk, dict):
+            return buffer, False, None
+        if chunk.get("type") == "end":
+            return buffer, True, None
+        if self.__is_ai_response_chunk(chunk):
+            return buffer + self.__extract_ai_response(chunk), False, None
+        return buffer, False, None
 
     # extract metadata from a single turn's response (for per-turn telemetry mode)
     def __extract_turn_metadata(self, response):
@@ -404,38 +424,24 @@ class Bot(ResponseExtractor):
                 f"502/Testing AI Agent error - Cannot generate completion. - {url_pattern.sub(truncate, str(e))}."
             )
 
-    # streaming case
+    # WebSocket streaming.
     async def __listen(self, socket):
-        # Listens for a message and returns the buffer (complete message) once done
-        # handle timeout
         async def read_complete_message():
             buffer, t_start = "", time.time()
             while True:
                 raw_data = await socket.recv()
-
-                # if chunk NOT in the expected json format break - message is completed
                 try:
                     chunk = json.loads(raw_data)
-                except:
+                except Exception:
                     break
-
-                if not isinstance(chunk, dict) or "type" not in chunk:
-                    continue
-
-                if chunk["type"] == "end":
+                buffer, stop, _ = self.__process_chunk(chunk, buffer)
+                if stop:
                     break
-
-                if not self.__is_ai_response_chunk(chunk):
-                    continue
-
-                # all ok - append content data (ai agent resonse stream - deltas)
-                buffer += self.__extract_ai_response(chunk)
-
             return buffer, time.time() - t_start
 
         try:
             return await asyncio.wait_for(read_complete_message(), REQUESTS_TIMEOUT)
-        except:
+        except Exception:
             await asyncio.wait_for(socket.close(), REQUESTS_TIMEOUT)
             raise
 
@@ -500,6 +506,74 @@ class Bot(ResponseExtractor):
                 f"502/Testing AI Agent error - Cannot stream completion. - {url_pattern.sub(truncate, str(e))}."
             )
 
+    # SSE streaming. Same chunk contract as WS; per-turn telemetry not supported.
+    async def __stream_sse(self, base_payload, u_prompt, conversation=None):
+        try:
+            endpoint = self.__prepare_endpoint(
+                self.bot_config["chat_completion"]["endpoint"], base_payload
+            )
+            headers = self.__prepare_headers(
+                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
+                base_payload,
+            )
+            headers.setdefault("user-agent", SSE_DEFAULT_USER_AGENT)
+            payload = self.__prepare_payload(
+                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
+                base_payload,
+                u_prompt,
+                conversation,
+            )
+
+            buffer, t_start = "", time.time()
+            async with httpx.AsyncClient(
+                timeout=REQUESTS_TIMEOUT,
+                verify=ssl_context,
+                follow_redirects=True,
+            ) as client:
+                async with client.stream(
+                    "POST",
+                    endpoint,
+                    headers=headers,
+                    json=payload,
+                ) as resp:
+                    resp.raise_for_status()
+                    async for line in resp.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        data = line[len("data:") :].strip()
+                        if not data:
+                            continue
+                        try:
+                            chunk = json.loads(data)
+                        except json.JSONDecodeError:
+                            continue
+                        buffer, stop, _ = self.__process_chunk(chunk, buffer)
+                        if stop:
+                            break
+
+            return buffer, time.time() - t_start, None
+
+        except (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException):
+            raise Exception(
+                f"408/Testing AI Agent Error – Unable to stream completion. The request timed out after {REQUESTS_TIMEOUT} seconds."
+            )
+        except (AttributeError, ValueError) as e:
+            _log_error(
+                title=e.__class__.__name__,
+                description={
+                    "where": "ClientBot :: SSE Chat",
+                    "e": url_pattern.sub(truncate, str(e)),
+                    "trace": str(traceback.format_exc()),
+                },
+                tag="Exception",
+                hook="ENGINEERING",
+            )
+            raise Exception("500/Testing AI Agent error [internal] - Cannot generate completion.")
+        except Exception as e:
+            raise Exception(
+                f"502/Testing AI Agent error - Cannot stream completion. - {url_pattern.sub(truncate, str(e))}."
+            )
+
     #
     # Public interface for thread initialization and chat completion
     #
@@ -542,15 +616,14 @@ class Bot(ResponseExtractor):
             )
 
     # STEP 2: Chat completion
-    # send the user prompt to the bot and get the response (streaming or non-streaming)
-    # Conduct the converation
+    # Conduct the conversation
     async def ping(self, base_payload, u_prompt, conversation=None):
-        a_resp = (
-            await self.__stream(base_payload, u_prompt, conversation)
-            if self.bot_config["streaming"]
-            else self.__chat(base_payload, u_prompt, conversation)
-        )
-        return a_resp
+        mode = self.bot_config.get("streaming")
+        if mode == "sse":
+            return await self.__stream_sse(base_payload, u_prompt, conversation)
+        if mode == "websocket":
+            return await self.__stream(base_payload, u_prompt, conversation)
+        return self.__chat(base_payload, u_prompt, conversation)
 
 
 #

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -1384,7 +1384,7 @@ def hb_connect(
 
     Args:
         endpoint_config: JSON string with the agent's chat-completion config.
-            Example: {"streaming": false, "chat_completion": {"endpoint": "https://...",
+            Example: {"streaming": null, "chat_completion": {"endpoint": "https://...",
             "headers": {"Authorization": "Bearer ..."}, "payload": {"content": "$PROMPT"}}}
         name: Project name (auto-derived from endpoint hostname if omitted).
         prompt_text: Optional system prompt text to include as an additional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ engine = [
     "anthropic>=0.20.0",
     "google-generativeai>=0.3.0",
     "websockets>=12.0",
+    "httpx>=0.27",
 ]
 firewall = [
     "humanbound-firewall>=0.2",

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -33,7 +33,7 @@ from humanbound_cli.engine.bot import (
 def bot_config():
     """Minimal bot config — REST, non-streaming."""
     return {
-        "streaming": False,
+        "streaming": None,
         "thread_auth": {"endpoint": "", "headers": {}, "payload": {}},
         "thread_init": {
             "endpoint": "https://agent.example/start",
@@ -92,7 +92,7 @@ def test_extract_ai_response_uses_custom_extractor(bot):
         def extract_custom_response(self, chunk):
             return chunk.get("weird_format_field")
 
-    b = CustomBot({"streaming": False}, "e1")
+    b = CustomBot({"streaming": None}, "e1")
     result = b._Bot__extract_ai_response({"weird_format_field": "custom value"})
     assert result == "custom value"
 
@@ -259,7 +259,7 @@ def test_extract_turn_metadata_returns_none_when_mode_not_per_turn(bot):
 
 def test_extract_turn_metadata_navigates_dot_path():
     config = {
-        "streaming": False,
+        "streaming": None,
         "telemetry": {
             "mode": "per_turn",
             "extraction_map": {"metadata_path": "data.autopilot.meta"},
@@ -272,7 +272,7 @@ def test_extract_turn_metadata_navigates_dot_path():
 
 def test_extract_turn_metadata_missing_path_returns_none():
     config = {
-        "streaming": False,
+        "streaming": None,
         "telemetry": {
             "mode": "per_turn",
             "extraction_map": {"metadata_path": "not.there"},


### PR DESCRIPTION
## Summary

Add SSE as a third chat-completion transport, alongside REST and WebSocket. The agent config's `streaming` field becomes an enum (`null` / `"websocket"` / `"sse"`) and content extraction is now
  permissive — customers can send native vendor shapes (OpenAI, Anthropic, RAG-style) without wrapping their bot's response.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [ ] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
