### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-06-09
+
 ### Added
 - **Server-Sent Events (SSE) as a third chat-completion transport.** Set
   `"streaming": "sse"` in the agent config; the engine reads `data:`-line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.0.5"
+version = "2.1.0"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release 2.1.0. Finalizes the changelog (`[Unreleased]` → `[2.1.0] — 2026-06-09`)
and bumps the package version `2.0.5` → `2.1.0`. No source changes — the
features and breaking change in this release (SSE streaming transport,
permissive content extraction, `streaming` config enum) already landed on
`main` in prior PRs.

## Type of change

- [x] Build / tooling / CI

## Checklist

- [ ] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed

## Linked issue(s)

<!-- none -->
