### PR TITLE
fix(campaigns): align campaign view with the API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`hb campaigns` no longer errors and `hb campaigns terminate` now finds a
+  running campaign.** The command read response fields that didn't match the
+  campaign API response; it now aligns with the actual response shape so the
+  plan renders and terminate locates the campaign.
+
 ## [2.2.0] — 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`hb assessments` list is more informative:** added Posture (grade + score)
+  and Drift columns, renamed the findings column to "New Findings" (explicitly
+  the new findings detected in the run), renamed "Scope" to "Domain" (the field
+  the API actually returns, previously shown blank), and render Started/
+  Completed as dates instead of raw epoch numbers.
+- **`hb assessments show` card is richer** instead of mirroring the list row:
+  it now shows the posture trajectory (before → after) with a trend read,
+  drift, coverage breadth (test groups + levels), the domain, and a
+  human-readable run duration.
+
 ### Fixed
 - **`hb campaigns` no longer errors and `hb campaigns terminate` now finds a
   running campaign.** The command read response fields that didn't match the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] — 2026-06-19
+
 ### Changed
 - **`hb assessments` list is more informative:** added Posture (grade + score)
   and Drift columns, renamed the findings column to "New Findings" (explicitly

--- a/humanbound_cli/commands/assessments.py
+++ b/humanbound_cli/commands/assessments.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024-2026 Humanbound
 """Assessment commands — view past security assessments."""
 
+import datetime as _dt
 import json
 
 import click
@@ -29,6 +30,21 @@ GRADE_STYLES = {
     "D": "[red]D[/red]",
     "F": "[red bold]F[/red bold]",
 }
+
+
+def _epoch_date(ts) -> str:
+    """Format an epoch-seconds value as YYYY-MM-DD (UTC).
+
+    started_at/completed_at come back as epoch numbers; the old code sliced
+    them as if they were ISO strings (showing raw epochs). Falls back to the
+    first 10 chars for an already-string value, or "" when absent.
+    """
+    if ts in (None, ""):
+        return ""
+    try:
+        return _dt.datetime.fromtimestamp(float(ts), _dt.timezone.utc).strftime("%Y-%m-%d")
+    except (TypeError, ValueError):
+        return str(ts)[:10]
 
 
 @click.group("assessments", invoke_without_command=True)
@@ -84,21 +100,39 @@ def assessments_group(ctx, page, size, as_json):
 
         table = Table(title="Assessments")
         table.add_column("ID", style="dim")
-        table.add_column("Scope", width=10)
+        table.add_column("Domain", width=18)  # fits "security, quality" on one line
         table.add_column("Status", width=12)
-        table.add_column("Findings", justify="right", width=10)
+        table.add_column("Posture", width=11)
+        table.add_column("Drift", justify="right", width=8)
+        table.add_column("New Findings", justify="right", width=12)
         table.add_column("Started", width=12)
         table.add_column("Completed", width=12)
 
         for a in assessments:
             status = str(a.get("status", "")).lower()
-            started = str(a.get("started_at", ""))[:10]
-            completed = str(a.get("completed_at", "") or "")[:10]
+            started = _epoch_date(a.get("started_at"))
+            completed = _epoch_date(a.get("completed_at"))
+
+            # Posture grade + score from the completion snapshot ({posture, grade}).
+            posture = a.get("posture_after") or {}
+            grade = posture.get("grade")
+            score = posture.get("posture")
+            posture_display = (
+                f"{GRADE_STYLES.get(str(grade), str(grade))} {score:.0f}"
+                if grade is not None and score is not None
+                else "—"
+            )
+
+            # Drift = change in posture vs the previous assessment.
+            drift = a.get("drift_score")
+            drift_display = f"{drift:+.2f}" if isinstance(drift, (int, float)) else "—"
 
             table.add_row(
                 str(a.get("id", "")),
-                a.get("scope", ""),
+                ", ".join(a.get("domain") or []),
                 STATUS_STYLES.get(status, status),
+                posture_display,
+                drift_display,
                 str(a.get("findings_discovered", "")),
                 started,
                 completed,
@@ -163,40 +197,91 @@ def show_assessment(assessment_id: str, as_json: bool):
 
 
 def _display_assessment(data: dict):
-    """Display assessment detail panel."""
-    status = str(data.get("status", "")).lower()
-    scope = data.get("scope", "security")
+    """Display assessment detail — richer than the list row.
 
-    # Posture before/after
+    Adds what the list can't show per row: the posture *trajectory*
+    (before → after) with a trend read, the drift, the coverage breadth, and
+    a human-readable run duration.
+    """
+    status = str(data.get("status", "")).lower()
+    activity = str(data.get("activity", "") or "")
+    domain = ", ".join(data.get("domain") or []) or "—"
+
+    # Posture trajectory. Snapshot dicts are {posture: score, grade}.
     before = data.get("posture_before") or {}
     after = data.get("posture_after") or {}
-    score_before = before.get("score", "—")
-    score_after = after.get("score", "—")
     grade_before = str(before.get("grade", "—"))
     grade_after = str(after.get("grade", "—"))
+    score_before = before.get("posture")
+    score_after = after.get("posture")
+    gb = GRADE_STYLES.get(grade_before, grade_before)
+    ga = GRADE_STYLES.get(grade_after, grade_after)
+    sb = f"{score_before:.0f}" if isinstance(score_before, (int, float)) else "—"
+    sa = f"{score_after:.0f}" if isinstance(score_after, (int, float)) else "—"
 
-    grade_before_styled = GRADE_STYLES.get(grade_before, grade_before)
-    grade_after_styled = GRADE_STYLES.get(grade_after, grade_after)
+    # Trend from the score delta (higher posture = better security).
+    trend = ""
+    if isinstance(score_before, (int, float)) and isinstance(score_after, (int, float)):
+        delta = score_after - score_before
+        if delta > 0:
+            trend = f"[green]▲ +{delta:.0f} improved[/green]"
+        elif delta < 0:
+            trend = f"[red]▼ {delta:.0f} regressed[/red]"
+        else:
+            trend = "[dim]→ no change[/dim]"
 
     drift = data.get("drift_score")
-    drift_display = f"{drift:+.2f}" if drift is not None else "—"
+    drift_display = f"{drift:+.2f}" if isinstance(drift, (int, float)) else "—"
+
+    # Coverage breadth from the discovery plan (count + testing levels).
+    entries = (data.get("discovery_plan") or {}).get("entries") or []
+    levels = sorted(
+        {str(e.get("level", "")) for e in entries if isinstance(e, dict) and e.get("level")}
+    )
+    coverage = f"{len(entries)} test group(s)" + (
+        f" · levels: {', '.join(levels)}" if levels else ""
+    )
+
+    # Timestamps are epoch seconds → render readable + compute duration.
+    def _fmt(ts):
+        try:
+            return _dt.datetime.fromtimestamp(float(ts), _dt.timezone.utc).strftime(
+                "%Y-%m-%d %H:%M:%S UTC"
+            )
+        except (TypeError, ValueError):
+            return None
+
+    started_raw = data.get("started_at")
+    completed_raw = data.get("completed_at")
+    started = _fmt(started_raw)
+    completed = _fmt(completed_raw)
+    duration = ""
+    try:
+        if started_raw and completed_raw:
+            secs = int(float(completed_raw) - float(started_raw))
+            if secs >= 0:
+                m, s = divmod(secs, 60)
+                duration = f"{m}m {s}s" if m else f"{s}s"
+    except (TypeError, ValueError):
+        pass
 
     lines = [
-        f"Scope: [bold]{scope}[/bold]",
-        f"Status: {STATUS_STYLES.get(status, status)}",
-        f"Tests: {data.get('test_count', '—')}",
+        f"Status:   {STATUS_STYLES.get(status, status)}",
+        f"Activity: {activity or '—'}",
+        f"Domain:   [bold]{domain}[/bold]",
+        f"Tests:    {data.get('test_count', '—')}",
         "",
-        f"Posture: {grade_before_styled} {score_before} → {grade_after_styled} {score_after}",
-        f"Drift: {drift_display}",
+        f"Posture:  {gb} {sb} → {ga} {sa}   {trend}".rstrip(),
+        f"Drift:    {drift_display}",
+        "",
+        f"Coverage: {coverage}",
     ]
-
-    started = str(data.get("started_at", ""))[:19]
-    completed = str(data.get("completed_at", "") or "")[:19]
     if started:
         lines.append("")
-        lines.append(f"[dim]Started: {started}[/dim]")
+        lines.append(f"[dim]Started:   {started}[/dim]")
     if completed:
-        lines.append(f"[dim]Completed: {completed}[/dim]")
+        suffix = f"   ([dim]{duration}[/dim])" if duration else ""
+        lines.append(f"[dim]Completed: {completed}[/dim]{suffix}")
 
     console.print(
         Panel(

--- a/humanbound_cli/commands/campaigns.py
+++ b/humanbound_cli/commands/campaigns.py
@@ -16,10 +16,11 @@ from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
 
-PHASE_STYLES = {
-    "reconnaissance": "[cyan]Reconnaissance[/cyan]",
-    "red_teaming": "[red]Red Teaming[/red]",
-    "monitoring": "[green]Monitoring[/green]",
+# Keys match the backend CampaignPhase enum values carried in `activity`.
+ACTIVITY_STYLES = {
+    "assess": "[cyan]Assess[/cyan]",
+    "investigate": "[yellow]Investigate[/yellow]",
+    "monitor": "[green]Monitor[/green]",
 }
 
 
@@ -70,14 +71,18 @@ def campaigns_group(ctx, as_json):
 
 
 def _display_campaign(response: dict):
-    """Display campaign plan details."""
+    """Display campaign plan details.
+
+    Mirrors the backend CampaignPlanResponse schema:
+    {id, activity, status, plan (dict), test_count, synthesized_strategies}.
+    """
     campaign = response.get("campaign", response)
 
-    phase = str(campaign.get("phase", campaign.get("current_phase", ""))).lower()
+    activity = str(campaign.get("activity", "") or "").lower()
     status = campaign.get("status", "")
     campaign_id = campaign.get("id", "")
 
-    phase_display = PHASE_STYLES.get(phase, phase)
+    activity_display = ACTIVITY_STYLES.get(activity, activity or "—")
     status_color = (
         "green"
         if status in ("completed", "active")
@@ -86,7 +91,7 @@ def _display_campaign(response: dict):
 
     console.print(
         Panel(
-            f"Phase: {phase_display}\n"
+            f"Activity: {activity_display}\n"
             f"Status: [{status_color}]{status}[/{status_color}]\n"
             f"[dim]ID: {campaign_id}[/dim]",
             title="Campaign Plan",
@@ -95,40 +100,34 @@ def _display_campaign(response: dict):
         )
     )
 
-    # Experiments in plan
-    experiments = campaign.get("experiments", campaign.get("plan", []))
-    if experiments:
-        console.print("\n[bold]Planned Experiments:[/bold]\n")
+    # Discovery plan — backend returns `plan` as a dict (discovery_plan), not a
+    # list of experiments. Render its top-level entries.
+    plan = campaign.get("plan", {})
+    if isinstance(plan, dict) and plan:
+        console.print("\n[bold]Discovery Plan:[/bold]\n")
 
         table = Table(show_header=True, header_style="bold")
-        table.add_column("Category", width=25)
-        table.add_column("Tests", justify="right", width=8)
-        table.add_column("Strategy", width=20)
-        table.add_column("Status", width=12)
+        table.add_column("Area", width=28)
+        table.add_column("Detail", overflow="fold")
 
-        for exp in experiments:
-            cat = exp.get("test_category", exp.get("category", ""))
-            if "/" in cat:
-                cat = cat.split("/")[-1]
-            tests = exp.get("test_count", exp.get("size", ""))
-            strategy = exp.get("strategy", "")
-            exp_status = exp.get("status", "pending")
-
-            status_style = {
-                "completed": "[green]completed[/green]",
-                "running": "[yellow]running[/yellow]",
-                "failed": "[red]failed[/red]",
-                "pending": "[dim]pending[/dim]",
-            }.get(str(exp_status).lower(), str(exp_status))
-
-            table.add_row(cat, str(tests), strategy, status_style)
+        for key, value in plan.items():
+            detail = (
+                json.dumps(value, default=str) if isinstance(value, list | dict) else str(value)
+            )
+            if len(detail) > 200:
+                detail = detail[:200] + "…"
+            table.add_row(str(key), detail)
 
         console.print(table)
 
     # Summary stats
-    total_tests = campaign.get("total_tests", campaign.get("total_size", 0))
-    if total_tests:
-        console.print(f"\n[dim]Total tests planned: {total_tests}[/dim]")
+    test_count = campaign.get("test_count", 0)
+    if test_count:
+        console.print(f"\n[dim]Total tests planned: {test_count}[/dim]")
+
+    synthesized = campaign.get("synthesized_strategies", []) or []
+    if synthesized:
+        console.print(f"[dim]Synthesized strategies: {len(synthesized)}[/dim]")
 
 
 @campaigns_group.command("terminate")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.2.0"
+version = "2.2.1"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -158,15 +158,15 @@ def invoke(cmd_args, mock_client=None, patch_target=None):
 
 
 def assert_exit_ok(result):
-    assert (
-        result.exit_code == 0
-    ), f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
+    assert result.exit_code == 0, (
+        f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
+    )
 
 
 def assert_exit_error(result, code=1):
-    assert (
-        result.exit_code == code
-    ), f"Expected exit {code}, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
+    assert result.exit_code == code, (
+        f"Expected exit {code}, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
+    )
 
 
 def assert_valid_json(result):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -313,15 +313,27 @@ MOCK_API_KEY = {
     "created_at": "2025-01-01T00:00:00Z",
 }
 
+# Mirrors the backend AssessmentListItem schema (be/schemas/Responses.py):
+# posture snapshots are {posture: score, grade}, findings_discovered is the
+# new-findings delta. Keep in sync so the unit tests exercise the real shape.
 MOCK_ASSESSMENT = {
     "id": "asmnt-001",
-    "type": "assess",
+    "domain": ["security"],
     "status": "completed",
-    "grade": "B",
-    "score": 72.5,
-    "tests_run": 50,
-    "tests_passed": 36,
-    "created_at": "2025-06-01T12:00:00Z",
+    "activity": "investigate",
+    "test_count": 50,
+    "posture_before": {"posture": 60.0, "grade": "C"},
+    "posture_after": {"posture": 72.5, "grade": "B"},
+    "drift_score": -0.08,
+    "started_at": 1781845200,
+    "completed_at": 1781846717,
+    "findings_discovered": 3,
+    "discovery_plan": {
+        "entries": [
+            {"orchestrator": "humanbound/adversarial/autonomous_red_team", "level": "system"},
+            {"orchestrator": "humanbound/adversarial/_monitoring_test", "level": "acceptance"},
+        ]
+    },
 }
 
 # Mirrors the backend CampaignPlanResponse schema exactly

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -158,15 +158,15 @@ def invoke(cmd_args, mock_client=None, patch_target=None):
 
 
 def assert_exit_ok(result):
-    assert result.exit_code == 0, (
-        f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
-    )
+    assert (
+        result.exit_code == 0
+    ), f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
 
 
 def assert_exit_error(result, code=1):
-    assert result.exit_code == code, (
-        f"Expected exit {code}, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
-    )
+    assert (
+        result.exit_code == code
+    ), f"Expected exit {code}, got {result.exit_code}.\nOutput:\n{result.output[:500]}"
 
 
 def assert_valid_json(result):
@@ -324,11 +324,20 @@ MOCK_ASSESSMENT = {
     "created_at": "2025-06-01T12:00:00Z",
 }
 
+# Mirrors the backend CampaignPlanResponse schema exactly
+# (be/schemas/Campaign.py): {id, activity, status, plan (dict),
+# test_count, synthesized_strategies}. Keep in sync — a drift here is
+# what let the `campaign_id`/`plan`-shape mismatch ship unnoticed.
 MOCK_CAMPAIGN = {
     "id": "camp-001",
+    "activity": "assess",
     "status": "running",
-    "progress": {"completed": 5, "total": 10},
-    "created_at": "2025-06-01T00:00:00Z",
+    "plan": {
+        "focus": "retest prior findings",
+        "targets": ["finding-1", "finding-2", "finding-3"],
+    },
+    "test_count": 10,
+    "synthesized_strategies": [],
 }
 
 MOCK_WEBHOOK = {

--- a/tests/unit/test_assessments.py
+++ b/tests/unit/test_assessments.py
@@ -46,6 +46,25 @@ class TestHappyPath:
         )
 
     @patch(PATCH_TARGET)
+    def test_list_shows_posture_drift_new_findings(self, MockClient):
+        """The list renders posture grade+score, drift, and the renamed
+        'New Findings' column from the real assessment shape."""
+        mock = _make_client()
+        mock.get.return_value = {"data": [MOCK_ASSESSMENT], "total": 1}
+        MockClient.return_value = mock
+        # Widen the console so the 8-column table doesn't truncate.
+        result = runner.invoke(cli, ["assessments"], env={"COLUMNS": "220"})
+        assert_exit_ok(result)
+        out = result.output
+        assert "New Findings" in out  # renamed column header
+        assert "Domain" in out and "security" in out  # scope→domain
+        assert "Posture" in out and "Drift" in out
+        assert "B" in out and "72" in out  # posture grade + score
+        assert "-0.08" in out  # drift
+        assert "3" in out  # new-findings delta
+        assert "2026-06-19" in out  # started/completed epoch rendered as date
+
+    @patch(PATCH_TARGET)
     def test_list_assessments_empty(self, MockClient):
         mock = _make_client()
         mock.get.return_value = {"data": [], "total": 0}
@@ -62,6 +81,23 @@ class TestHappyPath:
         result = runner.invoke(cli, ["assessments", "show", "asmnt-001"])
         assert_exit_ok(result)
         mock.get.assert_called_once_with("projects/proj-456/assessments/asmnt-001")
+
+    @patch(PATCH_TARGET)
+    def test_show_renders_rich_card(self, MockClient):
+        """The detail card adds info the list row can't: posture trajectory +
+        trend, drift, coverage breadth, domain, and run duration."""
+        mock = _make_client()
+        mock.get.return_value = MOCK_ASSESSMENT
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["assessments", "show", "asmnt-001"], env={"COLUMNS": "220"})
+        assert_exit_ok(result)
+        out = result.output
+        assert "C" in out and "B" in out  # posture before → after grades
+        assert "improved" in out  # trend (60 → 72)
+        assert "Drift" in out
+        assert "Coverage" in out and "acceptance" in out  # plan levels, no orchestrator names
+        assert "security" in out  # domain
+        assert "25m" in out  # duration (1517s)
 
     @patch(PATCH_TARGET)
     def test_list_json(self, MockClient):

--- a/tests/unit/test_campaigns.py
+++ b/tests/unit/test_campaigns.py
@@ -62,6 +62,21 @@ class TestHappyPath:
         assert "Not found" in result.output
 
     @patch(PATCH_TARGET)
+    def test_display_consumes_real_schema(self, MockClient):
+        """Regression: the backend returns `plan` as a dict and the id under
+        `id`. The old display iterated `plan` as a list of experiment dicts and
+        read `campaign_id`/`total_tests`, crashing with
+        'str object has no attribute get'. Render must succeed and show id +
+        test_count from the real CampaignPlanResponse shape."""
+        mock = _make_client()
+        mock.get_campaign.return_value = MOCK_CAMPAIGN  # real-shape fixture
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["campaigns"])
+        assert_exit_ok(result)
+        assert "camp-001" in result.output
+        assert "10" in result.output  # test_count rendered
+
+    @patch(PATCH_TARGET)
     def test_terminate_campaign(self, MockClient):
         mock = _make_client()
         mock.get_campaign.return_value = {"campaign": {"id": "camp-001", "status": "running"}}


### PR DESCRIPTION
`hb campaigns` errored and `hb campaigns terminate` reported "No active
campaign found" for a running campaign, because the command read fields
that didn't match the API response.

Aligns the command (and its test fixture) with the actual response shape
so the view renders and terminate locates the campaign.

Tests: 13 passing in tests/unit/test_campaigns.py.