### PR TITLE
feat(assessments): consolidate campaigns into assessments (deprecate hb campaigns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`hb assessments terminate [id]`** stops a running assessment (defaults to
+  the current/latest), and **`hb assessments show`** now defaults to the latest
+  assessment when no id is given. `hb assessments` is now the single command for
+  viewing and managing assessments.
+
+### Deprecated
+- **`hb campaigns`** is deprecated in favor of `hb assessments` (they are the
+  same records). It is hidden from help and prints a deprecation notice; it
+  still works.
+
 ## [2.2.1] — 2026-06-19
 
 ### Changed

--- a/docs/docs/reference/commands.md
+++ b/docs/docs/reference/commands.md
@@ -86,7 +86,8 @@ The complete `hb` CLI reference, organised into eight categories: global flags, 
 | `hb findings update <id>` | Update finding status or severity |
 | `hb findings assign <id>` | Assign finding to a team member |
 | `hb assessments` | List past security assessments |
-| `hb assessments show <id>` | View assessment detail (posture before/after, drift, test count) |
+| `hb assessments show [id]` | View assessment detail (posture trajectory, drift, coverage, duration); defaults to the latest |
+| `hb assessments terminate [id]` | Stop a running assessment (defaults to the current/latest) |
 | `hb assessments report <id>` | Generate assessment HTML report with full test logs (-o, --no-open) |
 | `hb projects report` | Generate project HTML security report (-o, --no-open) |
 | `hb orgs report` | Generate organisation-wide HTML report (-o, --no-open) |
@@ -97,8 +98,8 @@ The complete `hb` CLI reference, organised into eight categories: global flags, 
 | Command | Description |
 |---|---|
 | `hb guardrails` | Export learned security rules and patterns |
-| `hb campaigns` | View current ASCAM campaign plan |
-| `hb campaigns terminate` | Stop running campaign |
+| `hb campaigns` | _Deprecated_ — use `hb assessments` |
+| `hb campaigns terminate` | _Deprecated_ — use `hb assessments terminate` |
 | `hb monitor` | Start, pause, or resume continuous monitoring |
 
 ## Configuration

--- a/humanbound_cli/commands/assessments.py
+++ b/humanbound_cli/commands/assessments.py
@@ -8,6 +8,7 @@ import json
 import click
 from rich.console import Console
 from rich.panel import Panel
+from rich.prompt import Confirm
 from rich.table import Table
 
 from .. import telemetry
@@ -153,15 +154,17 @@ def assessments_group(ctx, page, size, as_json):
 
 
 @assessments_group.command("show")
-@click.argument("assessment_id")
+@click.argument("assessment_id", required=False)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 def show_assessment(assessment_id: str, as_json: bool):
-    """Show assessment details.
+    """Show assessment details (defaults to the latest assessment).
 
-    ASSESSMENT_ID: Assessment UUID.
+    ASSESSMENT_ID: Assessment UUID (optional; the latest assessment is shown
+    when omitted).
 
     \b
     Examples:
+      hb assessments show            # latest assessment
       hb assessments show <id>
       hb assessments show <id> --json
     """
@@ -179,6 +182,17 @@ def show_assessment(assessment_id: str, as_json: bool):
         raise SystemExit(1)
 
     try:
+        # Default to the latest assessment when no id is given.
+        if not assessment_id:
+            with console.status("Fetching latest assessment..."):
+                latest = client.get_campaign(project_id)
+            camp = latest.get("campaign", latest) if isinstance(latest, dict) else {}
+            assessment_id = (camp or {}).get("id", "")
+            if not assessment_id:
+                console.print("[yellow]No assessments found.[/yellow]")
+                console.print("[dim]Run 'hb test' to create one.[/dim]")
+                return
+
         with console.status("Fetching assessment..."):
             response = client.get(f"projects/{project_id}/assessments/{assessment_id}")
 
@@ -297,6 +311,71 @@ def _display_assessment(data: dict):
         f"  [bold]hb assessments report {data.get('id', '')}[/bold]  Generate full report"
     )
     console.print("  [bold]hb findings[/bold]                              View current findings")
+
+
+@assessments_group.command("terminate")
+@click.argument("assessment_id", required=False)
+@click.option("--force", is_flag=True, help="Skip confirmation prompt")
+def terminate_assessment(assessment_id: str, force: bool):
+    """Terminate a running assessment (defaults to the latest).
+
+    Stops the assessment and all of its running experiments.
+
+    \b
+    Examples:
+      hb assessments terminate          # the current/latest assessment
+      hb assessments terminate <id>
+      hb assessments terminate --force
+    """
+    client = HumanboundClient()
+
+    if not client.is_authenticated():
+        telemetry.fire_gated_command_hit()
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+
+    project_id = client.project_id
+    if not project_id:
+        console.print("[yellow]No project selected.[/yellow]")
+        console.print("Use 'hb projects use <id>' to select a project first.")
+        raise SystemExit(1)
+
+    try:
+        # Default to the current/latest assessment when no id is given.
+        status = ""
+        if not assessment_id:
+            with console.status("Fetching current assessment..."):
+                response = client.get_campaign(project_id)
+            camp = response.get("campaign", response) if isinstance(response, dict) else {}
+            assessment_id = (camp or {}).get("id", "")
+            status = (camp or {}).get("status", "")
+            if not assessment_id:
+                console.print("[yellow]No active assessment found.[/yellow]")
+                return
+
+        if status in ("completed", "broken"):
+            console.print(f"[yellow]Assessment is already {status}.[/yellow]")
+            return
+
+        if not force:
+            if not Confirm.ask(
+                f"Terminate assessment [bold]{assessment_id}[/bold]? Running experiments will be stopped"
+            ):
+                console.print("[dim]Cancelled.[/dim]")
+                return
+
+        with console.status("Terminating assessment..."):
+            client.terminate_campaign(project_id, assessment_id)
+
+        console.print("[green]Assessment terminated.[/green]")
+        console.print(f"[dim]ID: {assessment_id}[/dim]")
+
+    except NotAuthenticatedError:
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
 
 
 @assessments_group.command("report")

--- a/humanbound_cli/commands/campaigns.py
+++ b/humanbound_cli/commands/campaigns.py
@@ -79,8 +79,8 @@ def campaigns_group(ctx, as_json):
 def _display_campaign(response: dict):
     """Display campaign plan details.
 
-    Mirrors the backend CampaignPlanResponse schema:
-    {id, activity, status, plan (dict), test_count, synthesized_strategies}.
+    Mirrors the campaign plan API response:
+    {id, activity, status, plan (dict), test_count, synthesized_strategies (int count)}.
     """
     campaign = response.get("campaign", response)
 
@@ -131,9 +131,11 @@ def _display_campaign(response: dict):
     if test_count:
         console.print(f"\n[dim]Total tests planned: {test_count}[/dim]")
 
-    synthesized = campaign.get("synthesized_strategies", []) or []
-    if synthesized:
-        console.print(f"[dim]Synthesized strategies: {len(synthesized)}[/dim]")
+    # API returns a count (int); tolerate the legacy list shape during rollout.
+    raw = campaign.get("synthesized_strategies")
+    count = raw if isinstance(raw, int) else len(raw or [])
+    if count:
+        console.print(f"[dim]Synthesized strategies: {count}[/dim]")
 
 
 @campaigns_group.command("terminate")

--- a/humanbound_cli/commands/campaigns.py
+++ b/humanbound_cli/commands/campaigns.py
@@ -24,18 +24,24 @@ ACTIVITY_STYLES = {
 }
 
 
-@click.group("campaigns", invoke_without_command=True)
+@click.group("campaigns", invoke_without_command=True, hidden=True)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 @click.pass_context
 def campaigns_group(ctx, as_json):
-    """View and manage ASCAM campaigns.
+    """[Deprecated] Use 'hb assessments' instead.
 
-    \b
-    Examples:
-      hb campaigns                   # Show current campaign plan
-      hb campaigns --json            # JSON output
-      hb campaigns terminate         # Terminate a running campaign
+    Campaigns and assessments are the same thing; this alias is kept for
+    backward compatibility.
     """
+    # Deprecation notice on stderr (skipped in --json mode to keep machine
+    # output clean). Shown for `hb campaigns` and its subcommands.
+    if not as_json:
+        click.secho(
+            "'hb campaigns' is deprecated — use 'hb assessments' instead.",
+            fg="yellow",
+            err=True,
+        )
+
     if ctx.invoked_subcommand is not None:
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.2.1"
+version = "2.3.0"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -313,9 +313,9 @@ MOCK_API_KEY = {
     "created_at": "2025-01-01T00:00:00Z",
 }
 
-# Mirrors the backend AssessmentListItem schema (be/schemas/Responses.py):
-# posture snapshots are {posture: score, grade}, findings_discovered is the
-# new-findings delta. Keep in sync so the unit tests exercise the real shape.
+# Mirrors the assessment list item API response: posture snapshots are
+# {posture: score, grade}, findings_discovered is the new-findings delta.
+# Keep in sync so the unit tests exercise the real shape.
 MOCK_ASSESSMENT = {
     "id": "asmnt-001",
     "domain": ["security"],
@@ -329,17 +329,18 @@ MOCK_ASSESSMENT = {
     "completed_at": 1781846717,
     "findings_discovered": 3,
     "discovery_plan": {
+        # Mirrors the discovery_plan shape returned by the API.
         "entries": [
             {"orchestrator": "humanbound/adversarial/autonomous_red_team", "level": "system"},
-            {"orchestrator": "humanbound/adversarial/_monitoring_test", "level": "acceptance"},
+            {"orchestrator": "humanbound/adversarial/_redacted", "level": "acceptance"},
         ]
     },
 }
 
-# Mirrors the backend CampaignPlanResponse schema exactly
-# (be/schemas/Campaign.py): {id, activity, status, plan (dict),
-# test_count, synthesized_strategies}. Keep in sync — a drift here is
-# what let the `campaign_id`/`plan`-shape mismatch ship unnoticed.
+# Mirrors the campaign plan API response exactly: {id, activity, status,
+# plan (dict), test_count, synthesized_strategies (int count)}. Keep in sync
+# — a drift here is what let the `campaign_id`/`plan`-shape mismatch ship
+# unnoticed.
 MOCK_CAMPAIGN = {
     "id": "camp-001",
     "activity": "assess",
@@ -349,7 +350,7 @@ MOCK_CAMPAIGN = {
         "targets": ["finding-1", "finding-2", "finding-3"],
     },
     "test_count": 10,
-    "synthesized_strategies": [],
+    "synthesized_strategies": 0,
 }
 
 MOCK_WEBHOOK = {

--- a/tests/unit/test_assessments.py
+++ b/tests/unit/test_assessments.py
@@ -100,6 +100,47 @@ class TestHappyPath:
         assert "25m" in out  # duration (1517s)
 
     @patch(PATCH_TARGET)
+    def test_show_defaults_to_latest(self, MockClient):
+        """`hb assessments show` with no id resolves and renders the latest."""
+        mock = _make_client()
+        mock.get_campaign.return_value = {"id": "asmnt-001", "status": "completed"}
+        mock.get.return_value = MOCK_ASSESSMENT
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["assessments", "show"], env={"COLUMNS": "220"})
+        assert_exit_ok(result)
+        mock.get_campaign.assert_called_once_with("proj-456")
+        mock.get.assert_called_once_with("projects/proj-456/assessments/asmnt-001")
+        assert "improved" in result.output  # rich card rendered for the latest
+
+    @patch(PATCH_TARGET)
+    def test_terminate_latest(self, MockClient):
+        mock = _make_client()
+        mock.get_campaign.return_value = {"id": "camp-1", "status": "running"}
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["assessments", "terminate", "--force"])
+        assert_exit_ok(result)
+        mock.terminate_campaign.assert_called_once_with("proj-456", "camp-1")
+
+    @patch(PATCH_TARGET)
+    def test_terminate_with_explicit_id(self, MockClient):
+        mock = _make_client()
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["assessments", "terminate", "abc-123", "--force"])
+        assert_exit_ok(result)
+        mock.terminate_campaign.assert_called_once_with("proj-456", "abc-123")
+        mock.get_campaign.assert_not_called()  # explicit id ⇒ no lookup
+
+    @patch(PATCH_TARGET)
+    def test_terminate_none_active(self, MockClient):
+        mock = _make_client()
+        mock.get_campaign.return_value = {"id": "", "status": ""}
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["assessments", "terminate", "--force"])
+        assert_exit_ok(result)
+        assert "No active assessment" in result.output
+        mock.terminate_campaign.assert_not_called()
+
+    @patch(PATCH_TARGET)
     def test_list_json(self, MockClient):
         mock = _make_client()
         mock.get.return_value = {"data": [MOCK_ASSESSMENT], "total": 1}

--- a/tests/unit/test_campaigns.py
+++ b/tests/unit/test_campaigns.py
@@ -43,6 +43,17 @@ class TestHappyPath:
         mock.get_campaign.assert_called_once_with("proj-456")
 
     @patch(PATCH_TARGET)
+    def test_deprecation_warning(self, MockClient):
+        """`hb campaigns` is a deprecated alias for `hb assessments`."""
+        mock = _make_client()
+        mock.get_campaign.return_value = MOCK_CAMPAIGN
+        MockClient.return_value = mock
+        result = runner.invoke(cli, ["campaigns"])
+        assert_exit_ok(result)
+        assert "deprecated" in result.output.lower()
+        assert "hb assessments" in result.output
+
+    @patch(PATCH_TARGET)
     def test_campaign_status_json(self, MockClient):
         mock = _make_client()
         mock.get_campaign.return_value = MOCK_CAMPAIGN


### PR DESCRIPTION
## What
Consolidates the campaign/assessment commands into a single `hb assessments`.
`hb campaigns` and `hb assessments` operated on the same records, so having two
top-level commands was confusing.

## Changes
- **`hb assessments show [id]`** — `id` is now optional; defaults to the latest
  assessment (replaces the old `hb campaigns` view).
- **`hb assessments terminate [id]`** — new; stops a running assessment,
  defaults to the current/latest.
- **`hb assessments`** stays the list view (posture, drift, domain, new findings).
- **`hb campaigns` is deprecated, not removed** — hidden from `--help`, prints a
  deprecation notice on stderr, and still works. The notice is suppressed in
  `--json` mode so machine output stays clean.

## Notes
- No backend changes — same API endpoints.
- Docs (`reference/commands.md`) and CHANGELOG updated.
- Version bumped to **2.3.0** (minor: additive + deprecation).

## Tests
`test_assessments.py` / `test_campaigns.py` cover terminate (latest /
explicit-id / none-active), show-defaults-to-latest, and the deprecation
notice. Full unit suite green; ruff lint + format clean.