### PR TITLE
chore(release): date CHANGELOG for v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] — 2026-06-29
+
 ### Added
 - **`hb assessments terminate [id]`** stops a running assessment (defaults to
   the current/latest), and **`hb assessments show`** now defaults to the latest
@@ -333,5 +335,6 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/humanbound/humanbound/releases/tag/v2.3.0
 [2.0.0]: https://github.com/humanbound/humanbound/releases/tag/v2.0.0


### PR DESCRIPTION
Dates the `[Unreleased]` CHANGELOG entries under a `[2.3.0] — 2026-06-29` heading and refreshes the comparison links, ahead of cutting the v2.3.0 release.

Pairs with the draft GitHub release for `v2.3.0`. Merge this, then publish the draft (which tags `v2.3.0` at `main`'s HEAD).

### Contents of 2.3.0 (already on main via #39)
- `hb assessments terminate [id]` + `hb assessments show` defaulting to latest; `hb assessments` is the single command for viewing/managing assessments.
- `hb campaigns` deprecated in favor of `hb assessments`.

No code changes — CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)