### PR TITLE
feat(connect): add `hb connect --vendor` hosted-platform discovery on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`hb connect --vendor <id>`** discovers hosted-platform agents (currently `openai`) from a
+  vendor credential and onboards the one you pick — the credential is read from the vendor's
+  env var (e.g. `OPENAI_API_KEY`) or a hidden prompt, never from the command line. The picked
+  agent becomes the project's integration. Requires being logged in.
+
+### Changed
+- The offline local engine (`hb test --local`) now fails fast with a clear error when given a
+  hosted-platform connector config, instead of an opaque per-conversation failure. Connectors
+  work via `hb connect` (SaaS); the offline engine remains classic HTTP/SSE/WebSocket only.
+
+### Documentation
+- Documented that `hb connect --endpoint` also accepts a hosted-platform connector block
+  (`{ "connector": { "provider": "openai_assistants", "config": { … } } }`), not only the
+  classic HTTP shape.
+
 ## [2.3.0] — 2026-06-29
 
 ### Added

--- a/docs/docs/getting-started/agent-config.md
+++ b/docs/docs/getting-started/agent-config.md
@@ -113,6 +113,46 @@ The `--endpoint / -e` flag on `hb connect` accepts a JSON config file (or inline
 !!! info "Tip"
     Save your config file as `bot-config.json` (or `agent-config.json`) in your project root and use `hb connect -n "My Agent" -e ./bot-config.json` to connect with the integration pre-configured.
 
+## Hosted-Platform Connector
+
+Instead of the classic HTTP shape, `--endpoint` also accepts a **connector** block that
+drives an agent deployed on a hosted platform (currently OpenAI Assistants) — no self-hosted
+server needed:
+
+```json
+{
+  "connector": {
+    "provider": "openai_assistants",
+    "config": {
+      "api_key": "sk-...",
+      "target_id": "asst_..."
+    }
+  }
+}
+```
+
+!!! note "Assistants API deprecation"
+    The Assistants API is deprecated and will be removed in August 2026. The recommended
+    replacement is the Responses API. A Responses-based connector (`openai_responses`) is
+    planned and will run alongside `openai_assistants`.
+
+- `provider` — the connector transport (`openai_assistants` today).
+- `config.api_key` / `config.target_id` — the platform credential and the assistant id.
+- `config.input_template` — *advanced, optional.* A JSON envelope sent as the message text, with
+  any exact `"$PROMPT"` value swapped for the prompt (e.g. `{ "message": "$PROMPT" }` → the
+  assistant receives `{"message": "<prompt>"}`). Omit it to send the prompt as plain text; use a
+  template only if your assistant is built to read a JSON envelope.
+
+To discover these values automatically instead of hand-writing them, use
+`hb connect --vendor openai` (see [Discovery](../integrations/discovery.md)).
+
+!!! warning "Offline caveat"
+    A connector config works whenever the test runs on the platform — both `hb connect`
+    and a logged-in `hb test` send it to the backend, which hosts the conversation. It does
+    **not** work in the offline local engine (`hb test --local`, or `hb test` while logged
+    out), which implements only the classic HTTP/SSE/WebSocket transport and rejects
+    connector configs with a clear error.
+
 ## Telemetry (Optional)
 
 The `telemetry` block enables **whitebox agentic testing**. When present, Humanbound fetches tool calls, memory operations, and resource usage from your observability platform after each conversation, giving the judge visibility into what the agent *did* -- not just what it *said*.

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -170,6 +170,9 @@ hb login
 
 ```bash
 hb connect --endpoint ./bot-config.json
+
+# Or discover a hosted-platform agent (currently OpenAI Assistants)
+hb connect --vendor openai
 ```
 
 This probes your agent, extracts scope, creates a project, and runs a first test.

--- a/docs/docs/integrations/discovery.md
+++ b/docs/docs/integrations/discovery.md
@@ -1,118 +1,54 @@
 ---
-description: "Discover and assess AI services across your cloud environment — a client-side scan that surfaces shadow AI and feeds findings into the platform."
+description: "Discover the agents deployed on a hosted platform (e.g. OpenAI Assistants) from a vendor credential and onboard one as a Humanbound project — no hand-written config."
 keywords:
-  - AI discovery
-  - hb discover command
-  - shadow AI detection
-  - cloud AI inventory
-  - Microsoft AI scanner
-  - AI asset inventory
-  - cloud connectors
-  - model lifecycle tracking
+  - vendor discovery
+  - hb connect --vendor
+  - OpenAI Assistants onboarding
+  - hosted platform agents
+  - agent discovery
 ---
 
-# AI Discovery
+# Agent Discovery
 
-Discover and assess AI services across your cloud environment. The discovery pipeline scans your tenant client-side, sends results to the Humanbound platform for security evaluation (38 evidence signals, 15 SAI threat classes), and produces an assessed inventory with posture scoring and model lifecycle tracking.
+Onboard an agent deployed on a hosted platform (currently OpenAI Assistants) without writing a
+connector config by hand: `hb connect --vendor` lists the agents your credential can see
+and turns the one you pick into a Humanbound project. Requires being logged in (`hb login`).
 
-## Discovery
+## How it works
 
-Run `hb discover` to scan your cloud environment for AI services. The scanner authenticates via device-code flow, queries multiple API layers (service principals, sign-in logs, resource graph, Copilot Studio agents, Azure OpenAI deployments), and sends results to the platform for analysis.
-
-```bash
-# Scan and display results
-$ hb discover
-
-# Scan, save to inventory, and export HTML report
-$ hb discover --save --report
-
-# Verbose mode (show raw API responses from each layer)
-$ hb discover --verbose
-
-# Output as JSON
-$ hb discover --json
-```
-
-The discovery report includes:
-
-- **Deployed Agents** -- Copilot Studio agents with channel, auth, and network details
-- **AI Endpoints** -- Azure OpenAI deployments with model lifecycle badges (retired, deprecated, retiring soon)
-- **AI Adoption** -- Licensed and consented AI services (M365 Copilot, etc.)
-- **In Development** -- ML projects and staged resources
-- **Resource Topology** -- Interactive Mermaid diagram showing connections between agents, endpoints, models, and channels
-- **Security Evaluations** -- Per-service threat analysis with SAI threat classes, risk scores, and remediation guidance
-- **Posture Estimate** -- Organisation-level AI discovery posture score
-
-## Cloud Connectors
-
-Register cloud connectors for persistent discovery. Connectors store encrypted credentials and enable re-discovery (scheduled or on-demand).
+1. Pick a vendor: `hb connect --vendor openai`.
+2. Supply the credential — read from the vendor's env var (e.g. `OPENAI_API_KEY`) or a
+   hidden interactive prompt. Credentials are **never** passed on the command line.
+3. The backend queries the vendor API and returns your deployed agents (e.g. OpenAI
+   Assistants); the CLI lists them.
+4. Pick one — it becomes the project's `default_integration`, and the usual `hb connect`
+   flow continues (scope probe or `--scope`, project creation, first test).
 
 ```bash
-# Register a Microsoft connector
-$ hb connectors create --tenant-id <id> --client-id <id> --client-secret
+# Discover and onboard (reads $OPENAI_API_KEY or prompts)
+hb connect --vendor openai
 
-# Register with explicit vendor and display name
-$ hb connectors create --vendor microsoft --tenant-id <id> --client-id <id> --name "Production"
-
-# List connectors
-$ hb connectors
-
-# Export connectors as HTML report
-$ hb connectors --report
-
-# Test connectivity
-$ hb connectors test <connector-id>
-
-# Update credentials, name, or status
-$ hb connectors update <connector-id> --client-secret
-$ hb connectors update <connector-id> --name "New Name" --status disabled
-
-# Remove a connector
-$ hb connectors delete <connector-id>
+# Bring your own scope and project name
+hb connect --vendor openai --scope ./scope.yaml --name "Prod Assistant"
 ```
 
-## AI Inventory
+The discovery response is not persisted — only the picked agent's connector config is
+stored, and subsequent `hb test` runs use it automatically.
 
-After running `hb discover --save`, discovered assets are persisted to your AI inventory. Use the inventory commands to view, govern, and onboard assets for security testing.
+See [Agent Configuration](../getting-started/agent-config.md#hosted-platform-connector)
+for the connector config this produces, and the
+[commands reference](../reference/commands.md) for all `hb connect` flags.
 
-```bash
-# List all inventory assets
-$ hb inventory
+## Supported vendors
 
-# Export as HTML report
-$ hb inventory --report
+| Vendor | id | Credential |
+|---|---|---|
+| OpenAI (Assistants) | `openai` | API key (`OPENAI_API_KEY`) |
 
-# Filter by category, vendor, risk, or sanctioned status
-$ hb inventory --category copilot_studio_agent --risk-level high
-$ hb inventory --vendor microsoft --sanctioned
-$ hb inventory --unsanctioned --risk-level critical
+!!! note "Assistants API deprecation"
+    The Assistants API is deprecated and will be removed in August 2026. The recommended
+    replacement is the Responses API. A Responses-based connector (`openai_responses`) is
+    planned and will run alongside `openai_assistants`.
 
-# View asset details (with optional HTML report)
-$ hb inventory view <asset-id>
-$ hb inventory view <asset-id> --report
-
-# Update governance fields
-$ hb inventory update <asset-id> --sanctioned --owner "security@company.com"
-$ hb inventory update <asset-id> --department "Engineering" --business-purpose "Customer support"
-$ hb inventory update <asset-id> --has-policy --has-risk-assessment
-
-# View AI discovery posture (with optional HTML report)
-$ hb inventory posture
-$ hb inventory posture --report
-
-# Onboard an asset into a security testing project
-$ hb inventory onboard <asset-id>
-
-# Archive an asset
-$ hb inventory archive <asset-id>
-```
-
-## Model Lifecycle
-
-Discovery tracks model lifecycle status across all endpoints. Models approaching end-of-life are flagged with badges in both the CLI output and HTML report:
-
-- **RETIRED** -- Model is no longer available. Migrate immediately.
-- **DEPRECATED** -- Model is deprecated with a known retirement date.
-- **RETIRING SOON** -- Model retirement within 90 days. Plan migration.
-
-Lifecycle warnings appear in the hero metrics, executive summary, endpoints table, and resource topology diagram.
+More vendors are added over time; `hb connect --vendor` with no valid id lists the
+currently supported ones.

--- a/docs/docs/reference/commands.md
+++ b/docs/docs/reference/commands.md
@@ -41,6 +41,7 @@ The complete `hb` CLI reference, organised into eight categories: global flags, 
 | `hb connect --no-test` | Connect and create project but skip the auto-test step |
 | `hb connect --test-category <path>` | Choose which test family the auto-test runs (default: `humanbound/adversarial/owasp_agentic`) |
 | `hb connect --scope ./scope.yaml` | Use a pre-made scope file as input; the backend analyses it and proposes additive intents before project creation |
+| `hb connect --vendor <id>` | Discover and onboard a hosted-platform agent (currently `openai`); credential from env or a hidden prompt; requires login; mutually exclusive with `--endpoint` |
 | `hb projects list` | List all projects in current org |
 | `hb projects use <id>` | Set active project for subsequent commands |
 | `hb projects show [id]` | Show project details (current or specific) |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - API Keys: management/api-keys.md
     - Team & Collaboration: management/collaboration.md
   - 🔌 Integrations:
+    - Agent Discovery: integrations/discovery.md
     - Telemetry (Whitebox): integrations/telemetry.md
     - CI/CD: integrations/cicd.md
     - SIEM: integrations/siem.md

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -35,6 +35,7 @@ from .exceptions import (
     NotFoundError,
     RateLimitError,
     SessionExpiredError,
+    ValidationError,
 )
 
 # HTML templates for OAuth callback pages
@@ -1280,6 +1281,23 @@ class HumanboundClient:
             data["scopes"] = scopes
         return self.post("connectors", data=data)
 
+    def discover_targets(self, vendor: str, credentials: dict) -> list:
+        """Enumerate a vendor's deployed agents via ``POST /discover``.
+
+        Stateless: returns the list of discovered targets (each an agnostic
+        descriptor with a nullable ``connector`` block). Nothing is persisted.
+        This is the NEW discovery contract — not the removed Shadow-AI
+        ``trigger_discovery``/``list_connectors`` methods.
+        """
+        if not self._organisation_id:
+            raise ValidationError("No organisation selected.")
+        resp = self.post(
+            "discover",
+            data={"vendor": vendor, "credentials": credentials},
+            timeout=LONG_TIMEOUT,
+        )
+        return resp.get("targets", [])
+
     def list_connectors(self) -> list:
         """List all connectors for the current organisation."""
         if not self._organisation_id:
@@ -1412,7 +1430,3 @@ class HumanboundClient:
         if project_name:
             data["name"] = project_name
         return self.post(f"inventory/{asset_id}/onboard", data=data)
-
-
-# Import ValidationError to this module
-from .exceptions import ValidationError

--- a/humanbound_cli/commands/connect.py
+++ b/humanbound_cli/commands/connect.py
@@ -13,7 +13,7 @@ import click
 from rich.console import Console
 from rich.panel import Panel
 
-from .. import telemetry
+from .. import telemetry, vendors
 from ..client import HumanboundClient
 from ..exceptions import APIError, NotAuthenticatedError
 from .test import _load_integration, _resolve_context
@@ -211,9 +211,13 @@ def _display_dashboard(name: str, risk_profile: dict, has_integration: bool, has
     )
 
 
-def _get_source_description(prompt: str, endpoint: str, repo: str, openapi: str) -> str:
+def _get_source_description(
+    prompt: str, endpoint: str, repo: str, openapi: str, vendor: str | None = None
+) -> str:
     """Short human description of which --flag sources were used."""
     sources = []
+    if vendor:
+        sources.append(f"vendor ({vendor})")
     if prompt:
         sources.append(f"prompt ({Path(prompt).name})")
     if endpoint:
@@ -340,6 +344,11 @@ def _derive_agent_name(endpoint: str) -> str:
 
 @click.command("connect")
 @click.option("--endpoint", "-e", help="Agent config JSON or file path")
+@click.option(
+    "--vendor",
+    type=click.Choice(vendors.ids()),
+    help="Discover & onboard a hosted-platform agent (e.g. openai). Mutually exclusive with --endpoint.",
+)
 @click.option("--name", "-n", help="Project name (optional, auto-generated)")
 @click.option("--prompt", "-p", type=click.Path(exists=True), help="System prompt file")
 @click.option("--repo", "-r", type=click.Path(exists=True), help="Repository path")
@@ -377,6 +386,7 @@ def _derive_agent_name(endpoint: str) -> str:
 )
 def connect_command(
     endpoint,
+    vendor,
     name,
     prompt,
     repo,
@@ -405,11 +415,18 @@ def connect_command(
     success = False
 
     try:
-        has_agent_flags = any([endpoint, prompt, repo, openapi, scope_path])
+        if vendor and endpoint:
+            console.print(
+                "[red]Use --vendor (discover) or --endpoint (config file), not both.[/red]"
+            )
+            raise SystemExit(1)
+
+        has_agent_flags = any([endpoint, vendor, prompt, repo, openapi, scope_path])
 
         if has_agent_flags:
             _connect_agent(
                 endpoint,
+                vendor,
                 name,
                 prompt,
                 repo,
@@ -448,6 +465,7 @@ def connect_command(
 
 def _connect_agent(
     endpoint,
+    vendor,
     name,
     prompt,
     repo,
@@ -466,18 +484,24 @@ def _connect_agent(
     regulatory mapping, and auto-test. Local flow derives scope + lightweight
     compliance from the user's configured LLM provider and writes scope.yaml.
     """
-    source_flags = [prompt, endpoint, repo, openapi, scope_path]
+    source_flags = [prompt, endpoint, vendor, repo, openapi, scope_path]
     if not any(source_flags):
         console.print("[yellow]No extraction source provided.[/yellow]")
         console.print(
-            "Use --endpoint, --prompt, --repo, --openapi, or --scope to specify a source."
+            "Use --endpoint, --vendor, --prompt, --repo, --openapi, or --scope to specify a source."
         )
         raise SystemExit(1)
 
-    if not name:
+    # Vendor discovery names the project from the picked assistant (set later).
+    if not name and not vendor:
         name = _derive_agent_name(endpoint) if endpoint else "local-agent"
 
     client = HumanboundClient()
+    if vendor and not (client.is_authenticated() and client.organisation_id):
+        console.print("[red]hb connect --vendor requires you to be logged in.[/red]")
+        console.print("[dim]Run 'hb login' first.[/dim]")
+        raise SystemExit(1)
+
     if client.is_authenticated() and client.organisation_id:
         _connect_agent_platform(
             client,
@@ -493,6 +517,7 @@ def _connect_agent(
             no_test=no_test,
             test_category_arg=test_category_arg,
             scope_path=scope_path,
+            vendor=vendor,
         )
     else:
         _connect_agent_local(endpoint, name, prompt, repo, openapi, context, level, yes, timeout)
@@ -512,6 +537,7 @@ def _connect_agent_platform(
     no_test=False,
     test_category_arg=None,
     scope_path=None,
+    vendor=None,
 ):
     """Platform flow: POST /scan -> create project -> auto-test -> dashboard."""
     resolved_category = test_category_arg or DEFAULT_TEST_CATEGORY
@@ -530,6 +556,16 @@ def _connect_agent_platform(
             f"[yellow]! {'/'.join(ignored)} ignored when --scope is set "
             f"(scope comes from the file).[/yellow]"
         )
+
+    # Resolve --vendor into a connector integration (discover -> pick -> build).
+    vendor_integration = None
+    if vendor:
+        credentials = _collect_credentials(vendor)
+        targets = _discover_targets_or_exit(client, vendor, credentials)
+        picked = _pick_target(targets, auto_yes=yes)
+        vendor_integration = _build_vendor_connector(picked, credentials)
+        if not name:
+            name = picked.get("name") or "hosted-agent"
 
     console.print(f"\n[bold]Connecting agent:[/bold] {name}\n")
 
@@ -553,11 +589,12 @@ def _connect_agent_platform(
                 {"source": "text", "data": {"text": _serialize_scope_to_text(user_scope)}}
             )
 
-            # If --endpoint is also passed, keep its config for default_integration
-            # but DO NOT include it as a /scan source (no agent probing).
-            if endpoint:
-                local_integration = _load_integration(endpoint)
-                chat_ep = local_integration.get("chat_completion", {}).get("endpoint", "")
+            # If --endpoint or --vendor is also passed, keep its config for
+            # default_integration but DO NOT include it as a /scan source.
+            integration = vendor_integration or (_load_integration(endpoint) if endpoint else None)
+            if integration:
+                local_integration = integration
+                chat_ep = integration.get("chat_completion", {}).get("endpoint", "")
                 console.print(
                     f"  [green]\u2713[/green] Endpoint integration: [dim]{chat_ep or '(from config)'}[/dim]"
                 )
@@ -626,14 +663,14 @@ def _connect_agent_platform(
                 else:
                     console.print("  [yellow]![/yellow] OpenAPI spec: could not parse")
 
-            # --endpoint -> endpoint source (API probing)
-            if endpoint:
-                bot_config = _load_integration(endpoint)
-                chat_ep = bot_config.get("chat_completion", {}).get("endpoint", "")
+            # --endpoint / --vendor -> endpoint source (API probing)
+            integration = vendor_integration or (_load_integration(endpoint) if endpoint else None)
+            if integration:
+                chat_ep = integration.get("chat_completion", {}).get("endpoint", "")
                 console.print(
                     f"  [green]\u2713[/green] Endpoint source: [dim]{chat_ep or '(from config)'}[/dim]"
                 )
-                sources.append({"source": "endpoint", "data": bot_config})
+                sources.append({"source": "endpoint", "data": integration})
 
             # Merge accumulated text parts into a single text source
             if text_parts:
@@ -692,7 +729,7 @@ def _connect_agent_platform(
                 console.print("[yellow]Cancelled.[/yellow]")
                 return
 
-        description = f"Project created via 'hb connect' from {_get_source_description(prompt, endpoint, repo, openapi)}"
+        description = f"Project created via 'hb connect' from {_get_source_description(prompt, endpoint, repo, openapi, vendor)}"
         with console.status("[dim]Creating project...[/dim]"):
             project_data = {
                 "name": name,
@@ -1119,6 +1156,105 @@ def _build_monitoring_message(risk_level: str, matching_regs: list) -> str:
     )
 
     return "\n".join(lines)
+
+
+# -- Vendor discovery (--vendor) -----------------------------------------------
+
+
+def _collect_credentials(vendor: str) -> dict:
+    """Collect a vendor's credential fields: env candidate first, else prompt.
+
+    Secret fields prompt with hidden input. A required field that is empty and
+    cannot be supplied (no env, no input) exits with a clear message. No secret
+    is ever read from argv.
+    """
+    import os
+
+    from rich.prompt import Prompt
+
+    spec = vendors.get(vendor)
+    creds: dict = {}
+    for field in spec["credentials"]:
+        value = None
+        for env_name in field.get("env", []):
+            if os.environ.get(env_name):
+                value = os.environ[env_name]
+                break
+        if value is None:
+            try:
+                value = Prompt.ask(field["label"], password=field.get("secret", False))
+            except (EOFError, click.Abort):
+                value = None
+        if not value:
+            envs = " or ".join(f"${e}" for e in field.get("env", [])) or "the credential"
+            console.print(f"[red]Missing {field['label']}.[/red] Set {envs} or run interactively.")
+            raise SystemExit(1)
+        creds[field["name"]] = value
+    return creds
+
+
+def _discover_targets_or_exit(client, vendor: str, credentials: dict) -> list:
+    """Call POST /discover; exit cleanly on auth failure or empty result."""
+    try:
+        with console.status("[dim]Discovering deployed agents...[/dim]"):
+            targets = client.discover_targets(vendor, credentials)
+    except APIError as e:
+        console.print(f"[red]Discovery failed:[/red] {e}")
+        console.print("[dim]The vendor credential may be invalid or the service unreachable.[/dim]")
+        raise SystemExit(1)
+    if not targets:
+        console.print("[yellow]No agents found for this credential.[/yellow]")
+        raise SystemExit(1)
+    return targets
+
+
+def _pick_target(targets: list, auto_yes: bool = False) -> dict:
+    """Render discovered targets and return the chosen one (auto when unambiguous)."""
+    from rich.prompt import IntPrompt
+    from rich.table import Table
+
+    if len(targets) == 1 or auto_yes:
+        chosen = targets[0]
+        label = chosen.get("name") or chosen["resource_id"]
+        console.print(f"  [green]✓[/green] Selected: [dim]{label}[/dim]")
+        return chosen
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("#", justify="right")
+    table.add_column("Name")
+    table.add_column("ID", style="dim")
+    table.add_column("Model", style="dim")
+    for i, t in enumerate(targets, 1):
+        table.add_row(
+            str(i),
+            t.get("name") or "(unnamed)",
+            t.get("resource_id", ""),
+            (t.get("attributes") or {}).get("model", ""),
+        )
+    console.print(table)
+    # Prompt with a range (not click.Choice's inline [1/2/.../N]) so it stays clean at any count.
+    n = len(targets)
+    while True:
+        choice = IntPrompt.ask(f"Which agent? \\[[bold magenta]1-{n}[/bold magenta]]")
+        if 1 <= choice <= n:
+            return targets[choice - 1]
+        console.print(f"[red]Enter a number between 1 and {n}.[/red]")
+
+
+def _build_vendor_connector(picked: dict, credentials: dict) -> dict:
+    """Build a ``default_integration`` connector block, re-injecting the real credential.
+
+    The /discover response masks the secret; overwrite it with the real value the
+    caller holds so both the scan probe and the persisted integration use the true
+    credential. The connector ``provider`` is forwarded from the backend unchanged.
+    """
+    connector = picked["connector"]
+    return {
+        "connector": {
+            "provider": connector["provider"],
+            "config": {**connector["config"], **credentials},
+        }
+    }
 
 
 # -- Auto-test helper ----------------------------------------------------------

--- a/humanbound_cli/commands/connect.py
+++ b/humanbound_cli/commands/connect.py
@@ -347,7 +347,7 @@ def _derive_agent_name(endpoint: str) -> str:
 @click.option(
     "--vendor",
     type=click.Choice(vendors.ids()),
-    help="Discover & onboard a hosted-platform agent (e.g. openai). Mutually exclusive with --endpoint.",
+    help="Discover & onboard a hosted-platform agent from a vendor account. Mutually exclusive with --endpoint.",
 )
 @click.option("--name", "-n", help="Project name (optional, auto-generated)")
 @click.option("--prompt", "-p", type=click.Path(exists=True), help="System prompt file")
@@ -560,6 +560,9 @@ def _connect_agent_platform(
     # Resolve --vendor into a connector integration (discover -> pick -> build).
     vendor_integration = None
     if vendor:
+        notice = vendors.get(vendor).get("notice")
+        if notice:
+            console.print(Panel(notice, border_style="yellow", title="Deprecation notice"))
         credentials = _collect_credentials(vendor)
         targets = _discover_targets_or_exit(client, vendor, credentials)
         picked = _pick_target(targets, auto_yes=yes)

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -73,6 +73,11 @@ class ResponseExtractor:
 #
 class Bot(ResponseExtractor):
     def __init__(self, bot_config, e_id):
+        if "connector" in bot_config:
+            raise ValueError(
+                "Connector configs are not supported by the offline engine. "
+                "Use 'hb connect' (requires login) to test hosted-platform agents."
+            )
         self.bot_config = bot_config
         self.e_id = e_id
 

--- a/humanbound_cli/vendors.py
+++ b/humanbound_cli/vendors.py
@@ -12,6 +12,10 @@ discovery call, picker, connector build, and onboarding flow are vendor-agnostic
 VENDORS: dict[str, dict] = {
     "openai": {
         "label": "OpenAI",
+        "notice": (
+            "The Assistants API is deprecated and will be removed in August 2026. "
+            "The recommended replacement is the Responses API."
+        ),
         "credentials": [
             {
                 "name": "api_key",

--- a/humanbound_cli/vendors.py
+++ b/humanbound_cli/vendors.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""CLI vendor registry — the credential-field spec per hosted-platform vendor.
+
+Mirrors the backend ``VENDOR_REGISTRY`` / ``VENDOR_CREDENTIAL_MODELS``. Adding a
+vendor here (id -> label + credential fields) is all the CLI needs; the command,
+discovery call, picker, connector build, and onboarding flow are vendor-agnostic.
+"""
+
+# Each credential field: name (payload key), label (prompt text), secret (hide
+# input + mask), env (de-facto env var candidates, first set one wins).
+VENDORS: dict[str, dict] = {
+    "openai": {
+        "label": "OpenAI",
+        "credentials": [
+            {
+                "name": "api_key",
+                "label": "OpenAI API key",
+                "secret": True,
+                "env": ["OPENAI_API_KEY"],
+            },
+        ],
+    },
+}
+
+
+def ids() -> list[str]:
+    """Return the known vendor ids (sorted) — for ``click.Choice``."""
+    return sorted(VENDORS)
+
+
+def get(vendor: str) -> dict:
+    """Return the vendor spec; raise ``KeyError`` for an unknown id."""
+    return VENDORS[vendor]

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -21,6 +21,7 @@ from humanbound_cli.exceptions import (
     NotFoundError,
     RateLimitError,
     SessionExpiredError,
+    ValidationError,
 )
 
 # ---------------------------------------------------------------------------
@@ -485,3 +486,33 @@ class TestTokenRefresh:
 
         with pytest.raises(AuthenticationError, match="refresh failed"):
             client._refresh_token()
+
+
+class TestDiscoverTargets:
+    def test_posts_to_discover_and_returns_targets(self, client):
+        with patch("humanbound_cli.client.requests.post") as mock_post:
+            mock_post.return_value = _mock_response(
+                json_data={
+                    "vendor": "openai",
+                    "count": 1,
+                    "targets": [{"resource_id": "asst_1", "name": "FinAssist"}],
+                }
+            )
+            out = client.discover_targets("openai", {"api_key": "sk-real"})
+
+        assert out == [{"resource_id": "asst_1", "name": "FinAssist"}]
+        args, kwargs = mock_post.call_args
+        assert args[0].endswith("/discover")
+        assert kwargs["json"] == {
+            "vendor": "openai",
+            "credentials": {"api_key": "sk-real"},
+        }
+
+    def test_missing_targets_key_returns_empty_list(self, client):
+        with patch("humanbound_cli.client.requests.post") as mock_post:
+            mock_post.return_value = _mock_response(json_data={"vendor": "openai", "count": 0})
+            assert client.discover_targets("openai", {"api_key": "sk-real"}) == []
+
+    def test_requires_organisation(self, unauthenticated_client):
+        with pytest.raises(ValidationError):
+            unauthenticated_client.discover_targets("openai", {"api_key": "x"})

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -111,6 +111,7 @@ class TestHelpSurface:
             "--yes",
             "--context",
             "--endpoint",
+            "--vendor",
             "--no-test",
             "--test-category",
             "--scope",
@@ -934,3 +935,203 @@ class TestInitTelemetry:
         assert payload["no_test"] is True
         assert payload["test_category"] == "humanbound/adversarial/owasp_single_turn"
         assert payload["scope_provided"] is False
+
+
+# ---------------------------------------------------------------------------
+# Vendor registry
+# ---------------------------------------------------------------------------
+
+
+class TestVendorRegistry:
+    def test_ids_lists_openai(self):
+        from humanbound_cli import vendors
+
+        assert "openai" in vendors.ids()
+
+    def test_get_returns_openai_credential_fields(self):
+        from humanbound_cli import vendors
+
+        spec = vendors.get("openai")
+        assert spec["label"] == "OpenAI"
+        fields = spec["credentials"]
+        assert [f["name"] for f in fields] == ["api_key"]
+        assert fields[0]["secret"] is True
+        assert "OPENAI_API_KEY" in fields[0]["env"]
+
+    def test_get_unknown_vendor_raises(self):
+        from humanbound_cli import vendors
+
+        with pytest.raises(KeyError):
+            vendors.get("nope")
+
+
+# ---------------------------------------------------------------------------
+# Vendor onboarding helpers
+# ---------------------------------------------------------------------------
+
+
+class TestVendorHelpers:
+    def test_collect_credentials_from_env(self, monkeypatch):
+        from humanbound_cli.commands import connect
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        creds = connect._collect_credentials("openai")
+        assert creds == {"api_key": "sk-from-env"}
+
+    def test_collect_credentials_from_prompt(self, monkeypatch):
+        from humanbound_cli.commands import connect
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("rich.prompt.Prompt.ask", return_value="sk-typed") as ask:
+            creds = connect._collect_credentials("openai")
+        assert creds == {"api_key": "sk-typed"}
+        # secret field prompts with password=True
+        assert ask.call_args.kwargs.get("password") is True
+
+    def test_collect_credentials_missing_exits(self, monkeypatch):
+        from humanbound_cli.commands import connect
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("rich.prompt.Prompt.ask", return_value=""):
+            with pytest.raises(SystemExit):
+                connect._collect_credentials("openai")
+
+    def test_discover_targets_or_exit_empty_exits(self):
+        from humanbound_cli.commands import connect
+
+        client = MagicMock()
+        client.discover_targets.return_value = []
+        with pytest.raises(SystemExit):
+            connect._discover_targets_or_exit(client, "openai", {"api_key": "k"})
+
+    def test_discover_targets_or_exit_api_error_exits(self):
+        from humanbound_cli.commands import connect
+        from humanbound_cli.exceptions import APIError
+
+        client = MagicMock()
+        client.discover_targets.side_effect = APIError("bad key", 502, {})
+        with pytest.raises(SystemExit):
+            connect._discover_targets_or_exit(client, "openai", {"api_key": "k"})
+
+    def test_pick_target_single_auto_selects(self):
+        from humanbound_cli.commands import connect
+
+        t = {"resource_id": "asst_1", "name": "FinAssist"}
+        assert connect._pick_target([t]) is t
+
+    def test_pick_target_auto_yes_takes_first(self):
+        from humanbound_cli.commands import connect
+
+        targets = [{"resource_id": "a", "name": "A"}, {"resource_id": "b", "name": "B"}]
+        assert connect._pick_target(targets, auto_yes=True) is targets[0]
+
+    def test_pick_target_prompts_for_choice(self):
+        from humanbound_cli.commands import connect
+
+        targets = [{"resource_id": "a", "name": "A"}, {"resource_id": "b", "name": "B"}]
+        with patch("rich.prompt.IntPrompt.ask", return_value=2):
+            assert connect._pick_target(targets) is targets[1]
+
+    def test_pick_target_reprompts_on_out_of_range(self):
+        from humanbound_cli.commands import connect
+
+        targets = [{"resource_id": "a", "name": "A"}, {"resource_id": "b", "name": "B"}]
+        # First entry (9) is out of range → reprompt; second (1) is valid.
+        with patch("rich.prompt.IntPrompt.ask", side_effect=[9, 1]):
+            assert connect._pick_target(targets) is targets[0]
+
+    def test_build_vendor_connector_reinjects_real_key(self):
+        from humanbound_cli.commands import connect
+
+        picked = {
+            "resource_id": "asst_1",
+            "connector": {
+                "provider": "openai_assistants",
+                "config": {"api_key": "sk-****masked", "target_id": "asst_1"},
+            },
+        }
+        out = connect._build_vendor_connector(picked, {"api_key": "sk-real"})
+        assert out == {
+            "connector": {
+                "provider": "openai_assistants",
+                "config": {"api_key": "sk-real", "target_id": "asst_1"},
+            }
+        }
+
+
+# ---------------------------------------------------------------------------
+# Vendor flow (--vendor flag)
+# ---------------------------------------------------------------------------
+
+
+class TestVendorFlow:
+    @patch(PATCH_CLIENT)
+    def test_vendor_and_endpoint_conflict(self, MockCls):
+        MockCls.return_value = _make_authenticated_client()
+        result = runner.invoke(cli, ["connect", "--vendor", "openai", "--endpoint", "{}", "--yes"])
+        assert result.exit_code != 0
+        assert "not both" in result.output.lower()
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-real"})
+    @patch(PATCH_CLIENT)
+    def test_vendor_discovers_picks_and_creates_project(self, MockCls):
+        client = _make_authenticated_client()
+        client.discover_targets.return_value = [
+            {
+                "resource_id": "asst_1",
+                "name": "FinAssist",
+                "attributes": {"model": "gpt-4o"},
+                "connector": {
+                    "provider": "openai_assistants",
+                    "config": {"api_key": "sk-****masked", "target_id": "asst_1"},
+                },
+            }
+        ]
+        client.post.side_effect = lambda path, **kwargs: (
+            {
+                "scope": {
+                    "overall_business_scope": "Finance assistant",
+                    "intents": {"permitted": ["p1"], "restricted": ["r1"]},
+                },
+                "risk_profile": {"risk_level": "LOW", "industry": "fintech"},
+                "default_integration": {
+                    "connector": {
+                        "provider": "openai_assistants",
+                        "config": {"api_key": "sk-real", "target_id": "asst_1"},
+                    }
+                },
+            }
+            if path == "scan"
+            else {"id": "proj-new"}
+        )
+        MockCls.return_value = client
+
+        with (
+            patch("humanbound_cli.commands.connect._auto_test"),
+            patch("humanbound_cli.commands.connect._recommend_monitoring"),
+        ):
+            result = runner.invoke(cli, ["connect", "--vendor", "openai", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        client.discover_targets.assert_called_once_with("openai", {"api_key": "sk-real"})
+        # scan probed the picked connector, carrying the REAL key (not the masked one)
+        scan_calls = [c for c in client.post.call_args_list if c.args[0] == "scan"]
+        assert scan_calls, "POST /scan should have run"
+        sources = scan_calls[0].kwargs["data"]["sources"]
+        endpoint_sources = [s for s in sources if s["source"] == "endpoint"]
+        assert endpoint_sources, "connector should be sent as an endpoint source"
+        cfg = endpoint_sources[0]["data"]["connector"]["config"]
+        assert cfg["api_key"] == "sk-real"
+        assert cfg["target_id"] == "asst_1"
+        # project created, with a non-dangling description naming the vendor source
+        project_calls = [c for c in client.post.call_args_list if c.args[0] == "projects"]
+        assert project_calls
+        assert "vendor (openai)" in project_calls[0].kwargs["data"]["description"]
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-real"})
+    @patch(PATCH_CLIENT)
+    def test_vendor_requires_authentication(self, MockCls):
+        MockCls.return_value = _make_unauthenticated_client()
+        result = runner.invoke(cli, ["connect", "--vendor", "openai", "--yes"])
+        assert result.exit_code != 0
+        assert "log in" in result.output.lower() or "login" in result.output.lower()

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -1127,6 +1127,9 @@ class TestVendorFlow:
         project_calls = [c for c in client.post.call_args_list if c.args[0] == "projects"]
         assert project_calls
         assert "vendor (openai)" in project_calls[0].kwargs["data"]["description"]
+        # vendor's deprecation notice is surfaced (registry-driven, mirrors the UI banner)
+        assert "deprecated" in result.output
+        assert "Responses API" in result.output
 
     @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-real"})
     @patch(PATCH_CLIENT)

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -74,6 +74,18 @@ def test_bot_inherits_from_response_extractor(bot):
     assert isinstance(bot, ResponseExtractor)
 
 
+def test_bot_rejects_connector_config():
+    """The offline engine is classic-HTTP only; connector configs must fail fast."""
+    connector_cfg = {
+        "connector": {
+            "provider": "openai_assistants",
+            "config": {"api_key": "sk-x", "target_id": "asst_x"},
+        }
+    }
+    with pytest.raises(ValueError, match="not supported by the offline engine"):
+        Bot(connector_cfg, e_id="exp-abc")
+
+
 # ────────────────────────────────────────────────────────────────
 # __extract_ai_response — dict with standard keys, custom, fallback
 # ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…boarding

<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Discover a hosted-platform agent from a vendor credential, pick one, and
onboard it as the project's default_integration connector — reusing the
existing platform onboarding flow. Phase 1 vendor: openai.

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
