### PR TITLE
chore(release): 2.4.0 — date CHANGELOG, bump version, fix __version__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-07-03
+
 ### Added
 - **`hb connect --vendor <id>`** discovers hosted-platform agents (currently `openai`) from a
   vendor credential and onboards the one you pick — the credential is read from the vendor's
@@ -17,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The offline local engine (`hb test --local`) now fails fast with a clear error when given a
   hosted-platform connector config, instead of an opaque per-conversation failure. Connectors
   work via `hb connect` (SaaS); the offline engine remains classic HTTP/SSE/WebSocket only.
+
+### Fixed
+- `humanbound.__version__` now reads the installed package metadata instead of a hardcoded
+  string that had been stuck at `2.0.1` since that release.
 
 ### Documentation
 - Documented that `hb connect --endpoint` also accepts a hosted-platform connector block
@@ -351,6 +357,7 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/humanbound/humanbound/releases/tag/v2.4.0
 [2.3.0]: https://github.com/humanbound/humanbound/releases/tag/v2.3.0
 [2.0.0]: https://github.com/humanbound/humanbound/releases/tag/v2.0.0

--- a/humanbound/__init__.py
+++ b/humanbound/__init__.py
@@ -12,7 +12,12 @@ from `humanbound` for stability.
 
 from __future__ import annotations
 
-__version__ = "2.0.1"
+from importlib.metadata import version as _v
+
+try:
+    __version__ = _v("humanbound")
+except Exception:
+    __version__ = "dev"
 
 from humanbound.bot import Bot, ResponseExtractor
 from humanbound.callbacks import EngineCallbacks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.3.0"
+version = "2.4.0"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Move the [Unreleased] entries under a dated [2.4.0] heading and refresh the comparison links ahead of cutting the v2.4.0 release. Bump the package version in pyproject.toml (the feature PR didn't).

Also make humanbound.__version__ read the installed package metadata (same pattern as humanbound_cli) instead of a hardcoded string that had been stuck at "2.0.1" since that release.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
