### PR TITLE
feat(cli): make thread_init optional in bot runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`thread_init` is now optional in agent configs.** Stateless agents that need no session
+  step can omit `thread_init` — or leave its endpoint empty, or set it to `null`. `hb test`
+  and the local engine skip session creation when it isn't configured, mirroring the
+  already-optional `thread_auth`; only `chat_completion` is required. Configs that do provide
+  a `thread_init` endpoint are unchanged and still validated.
+
 ## [2.4.0] — 2026-07-03
 
 ### Added

--- a/docs/docs/getting-started/agent-config.md
+++ b/docs/docs/getting-started/agent-config.md
@@ -52,14 +52,14 @@ The `--endpoint / -e` flag on `hb connect` accepts a JSON config file (or inline
 ## Configuration Fields
 
 - **`chat_completion`** (required) -- The endpoint your agent listens on for chat messages. This is the only required section.
-- **`thread_init`** (required) -- Thread or session creation endpoint, called once per conversation before sending messages.
+- **`thread_init`** (optional) -- Thread or session creation endpoint, called once per conversation before sending messages. Omit it (or leave the endpoint empty) for stateless agents that need no session.
 - **`thread_auth`** (optional) -- For agents that require authentication (e.g., OAuth token exchange) before testing can begin.
 - **`$PROMPT`** -- The placeholder in the payload that gets replaced with each test prompt at runtime.
 - **`streaming`** -- Transport: `null` (REST, default), `"websocket"`, or `"sse"`. Leave `null` if your agent returns a single JSON response per request.
 - **`telemetry`** (optional) -- Enables white-box agentic testing by collecting tool calls, memory operations, and resource usage from your observability platform. See [Telemetry](#telemetry-optional) below.
 
 !!! info "Note"
-    At minimum, you must provide `chat_completion` and `thread_init`. `headers` and `payload` fields are required in each section but can be empty objects if not needed. Use them to pass API keys, content types, or other metadata as needed by your agent. If no `"$PROMPT"` placeholder is found in the payload, Humanbound will append the prompt to the end of the payload by default assuming OpenAI-style input. The agent output should be in the response body of the `chat_completion` endpoint for Humanbound to capture it for analysis. The expected response format is a JSON object with any of `content | text | response | resp | answer | ans | message | reply | output` field containing the agent's reply (Humanbound walks the response recursively, so the field can be nested).
+    At minimum, you must provide `chat_completion`. `headers` and `payload` fields are required in each section you include but can be empty objects if not needed. Use them to pass API keys, content types, or other metadata as needed by your agent. If no `"$PROMPT"` placeholder is found in the payload, Humanbound will append the prompt to the end of the payload by default assuming OpenAI-style input. The agent output should be in the response body of the `chat_completion` endpoint for Humanbound to capture it for analysis. The expected response format is a JSON object with any of `content | text | response | resp | answer | ans | message | reply | output` field containing the agent's reply (Humanbound walks the response recursively, so the field can be nested).
 
 ## Basic Example
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -159,11 +159,11 @@ Create a JSON file that tells Humanbound how to talk to your agent. The `$PROMPT
 |---|---|---|
 | `chat_completion` | Yes | The endpoint your agent listens on for chat messages. Use `$PROMPT` in the payload where user input goes. |
 | `thread_auth` | No | OAuth/token endpoint called before testing begins. The response payload (`access_token`, `refresh_token`, etc.) is captured and injected into subsequent requests. |
-| `thread_init` | Yes | Session/thread creation endpoint. Called once per conversation to initialize a thread before sending chat messages. |
+| `thread_init` | No | Session/thread creation endpoint, called once per conversation to initialize a thread before sending chat messages. Omit for stateless agents that need no session. |
 | `streaming` | No | Transport: `null` (REST, default), `"websocket"`, or `"sse"`. |
 
 !!! info "Minimal config"
-    `chat_completion` and `thread_init` are required. Skip `thread_auth` if your agent uses simple API key auth and doesn't need OAuth.
+    `chat_completion` is the only required section. Skip `thread_init` for stateless agents that need no session, and `thread_auth` if your agent uses simple API key auth and doesn't need OAuth.
 
 Then point Humanbound at it:
 

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -585,28 +585,32 @@ class Bot(ResponseExtractor):
 
     # STEP 1: Session start
     # - execute any required auth calls to get access tokens (will be used in init call and chat completion calls if needed)
-    # - start the thread/session with the bot
+    # - optionally start the thread/session; skipped when thread_init is not configured
     def init(self):
         try:
-            # 1.1 - execute any required auth calls to get access tokens (if related endpoint is defined)
-            endpoint = self.bot_config["thread_auth"]["endpoint"]
-            if endpoint != "":
-                base_payload, _, endpoint = self.__make_api_call(
+            # 1.1 - optional auth call; skipped when thread_auth is null/missing/empty-endpoint
+            auth = self.bot_config.get("thread_auth") or {}
+            if auth.get("endpoint", ""):
+                base_payload, _, _ = self.__make_api_call(
                     {},
-                    endpoint,
-                    copy.deepcopy(self.bot_config["thread_auth"]["headers"]),
-                    copy.deepcopy(self.bot_config["thread_auth"]["payload"]),
+                    auth["endpoint"],
+                    copy.deepcopy(auth.get("headers", {})),
+                    copy.deepcopy(auth.get("payload", {})),
                 )
                 time.sleep(1)  # small delay to avoid race conditions
             else:
                 base_payload = {}
 
-            # 2.2 - start the thread/session with the bot
-            temp_payload, _, endpoint = self.__make_api_call(
+            # 2.2 - optional thread/session start; skipped when thread_init is null/missing/empty-endpoint
+            init_cfg = self.bot_config.get("thread_init") or {}
+            if not init_cfg.get("endpoint", ""):
+                return base_payload
+
+            temp_payload, _, _ = self.__make_api_call(
                 base_payload,
-                self.bot_config["thread_init"]["endpoint"],
-                copy.deepcopy(self.bot_config["thread_init"]["headers"]),
-                copy.deepcopy(self.bot_config["thread_init"]["payload"]),
+                init_cfg["endpoint"],
+                copy.deepcopy(init_cfg.get("headers", {})),
+                copy.deepcopy(init_cfg.get("payload", {})),
             )
 
             # append the session start payload to the base payload

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -325,6 +325,54 @@ def test_init_with_auth_step_merges_payloads(bot_config):
     assert out == {"access_token": "tok", "session_id": "sess"}
 
 
+def test_init_skips_thread_init_when_endpoint_empty(bot_config):
+    bot_config["thread_auth"] = {"endpoint": "", "headers": {}, "payload": {}}
+    bot_config["thread_init"] = {"endpoint": "", "headers": {}, "payload": {}}
+    b = Bot(bot_config, "exp-1")
+    with patch("humanbound_cli.engine.bot.requests.post") as post:
+        out = b.init()
+    assert out == {}
+    post.assert_not_called()
+
+
+def test_init_skips_thread_init_when_null(bot_config):
+    bot_config["thread_auth"] = None
+    bot_config["thread_init"] = None
+    b = Bot(bot_config, "exp-1")
+    with patch("humanbound_cli.engine.bot.requests.post") as post:
+        out = b.init()
+    assert out == {}
+    post.assert_not_called()
+
+
+def test_init_skips_thread_init_when_missing(bot_config):
+    bot_config.pop("thread_auth", None)
+    bot_config.pop("thread_init", None)
+    b = Bot(bot_config, "exp-1")
+    with patch("humanbound_cli.engine.bot.requests.post") as post:
+        out = b.init()
+    assert out == {}
+    post.assert_not_called()
+
+
+def test_init_runs_auth_then_skips_thread_init(bot_config):
+    bot_config["thread_auth"] = {
+        "endpoint": "https://agent.example/auth",
+        "headers": {},
+        "payload": {},
+    }
+    bot_config["thread_init"] = None
+    b = Bot(bot_config, "exp-1")
+    with (
+        patch("humanbound_cli.engine.bot.requests.post") as post,
+        patch("humanbound_cli.engine.bot.time.sleep"),
+    ):
+        post.return_value = _mock_post(payload={"access_token": "tok"})
+        out = b.init()
+    assert out == {"access_token": "tok"}
+    assert post.call_count == 1  # auth fired, thread_init skipped
+
+
 def test_init_bad_status_raises(bot):
     with patch("humanbound_cli.engine.bot.requests.post") as post:
         post.return_value = _mock_post(status=500, text="boom")


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

init() skips the auth/thread_init calls when they are missing, null, or have an empty endpoint, so stateless agents need no session step.

- bot: tolerant init(), mirroring the backend clientbot change
- docs: agent-config + index now list chat_completion as the only required section; thread_init documented as optional
- tests: init skip cases in test_engine_bot

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
