### PR TITLE
chore(release): prepare v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-07-06
+
 ### Changed
 - **`thread_init` is now optional in agent configs.** Stateless agents that need no session
   step can omit `thread_init` — or leave its endpoint empty, or set it to `null`. `hb test`
@@ -364,7 +366,8 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/humanbound/humanbound/releases/tag/v2.5.0
 [2.4.0]: https://github.com/humanbound/humanbound/releases/tag/v2.4.0
 [2.3.0]: https://github.com/humanbound/humanbound/releases/tag/v2.3.0
 [2.0.0]: https://github.com/humanbound/humanbound/releases/tag/v2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.4.0"
+version = "2.5.0"
 description = "Humanbound — open-source AI agent red-team engine, SDK, and CLI."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Move the [Unreleased] entry under a dated [2.5.0] heading, refresh the comparison links, and bump the package version in pyproject.toml ahead of tagging v2.5.0.

## Type of change

- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] [CLA](https://github.com/humanbound/humanbound/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
