### PR TITLE
chore(release): date CHANGELOG for v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.6.0] — 2026-07-08
+## [2.6.0] — 2026-07-09
 
 ### Added
 - **`TestConfig` is now part of the public SDK namespace**


### PR DESCRIPTION
One-line release chore: set the 2.6.0 changelog date to the actual release day (2026-07-09), per the convention established for v2.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)