### PR TITLE
docs: record humanbound-cli stub yank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.6.0] — 2026-07-09
 
+### Removed
+- **`humanbound-cli` transitional stub retired.** All 29 `humanbound-cli`
+  releases on PyPI were yanked on 2026-07-09 (past the 2026-06-20 window
+  announced in 2.0.0), with the yank reason pointing users to
+  `pip install humanbound`. Pinned installs (`humanbound-cli==1.2.2`) still
+  work with a warning; unpinned installs now fail with the redirect message.
+
 ### Added
 - **`TestConfig` is now part of the public SDK namespace**
   (`from humanbound import TestConfig`). It was the only missing piece for

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ live on [docs.humanbound.ai](https://docs.humanbound.ai/).
 ## Release highlights
 
 - **Clean name**: `humanbound` is the PyPI install. The old `humanbound-cli`
-  package is a discontinued transitional stub; install `humanbound` directly.
+  package has been yanked from PyPI; install `humanbound` directly.
 - **Public SDK namespace** alongside the CLI — use the CLI or drive the
   engine from Python.
 - **Firewall integration**: `pip install humanbound[firewall]` pulls


### PR DESCRIPTION
## Summary

All 29 `humanbound-cli` releases were yanked on PyPI today (2026-07-09), honoring the "on or after 2026-06-20" window announced in 2.0.0, with the yank reason pointing users to `pip install humanbound`. This updates the README's Release highlights to past tense and records the retirement under `[2.6.0]` in the changelog. Land before tagging v2.6.0 so the release notes carry it.

(Unlike the firewall repo, no workflow change is needed — this repo's release pipeline never published the stub.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only
- [ ] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix — N/A, docs only
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally (no sources touched)
- [x] `CHANGELOG.md` updated (under `[2.6.0]`, unreleased)
- [x] Docs updated on `docs.humanbound.ai` — N/A
- [x] CLA signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)