### PR TITLE
Accept `anthropic` as an alias for the `claude` provider (fixes #53)

### DIFF
--- a/humanbound_cli/engine/llm/__init__.py
+++ b/humanbound_cli/engine/llm/__init__.py
@@ -4,6 +4,10 @@
 
 SUPPORTED_PROVIDERS = ["openai", "claude", "gemini", "grok", "azureopenai", "ollama"]
 
+# User-facing aliases → canonical provider name. "anthropic" matches both the
+# PyPI package and the wording in the README/[engine] extra ("Anthropic provider").
+PROVIDER_ALIASES = {"anthropic": "claude"}
+
 
 def get_llm_pinger(model_provider):
     """Return an LLMPinger instance for the given provider.
@@ -16,6 +20,7 @@ def get_llm_pinger(model_provider):
         LLMPinger instance with ping(system_p, user_p, max_tokens, temperature) method.
     """
     name = model_provider["name"] if isinstance(model_provider, dict) else model_provider.name
+    name = PROVIDER_ALIASES.get(name, name)
 
     if name == "azureopenai":
         from .azureopenai import LLMPinger

--- a/tests/unit/test_llm_pinger.py
+++ b/tests/unit/test_llm_pinger.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Tests for the LLM pinger factory and its provider aliases."""
+
+import pytest
+
+from humanbound_cli.engine.llm import PROVIDER_ALIASES, get_llm_pinger
+
+
+def test_anthropic_is_alias_for_claude():
+    assert PROVIDER_ALIASES["anthropic"] == "claude"
+
+
+def test_unsupported_provider_raises_clear_error():
+    with pytest.raises(ValueError, match="Unsupported LLM provider"):
+        get_llm_pinger({"name": "not-a-real-provider", "integration": {}})
+
+
+def test_anthropic_alias_is_not_rejected_as_unsupported():
+    # "anthropic" must resolve to the "claude" pinger. Building it may still fail
+    # if the anthropic SDK isn't installed, but it must NOT be rejected as an
+    # unsupported provider.
+    try:
+        get_llm_pinger({"name": "anthropic", "integration": {"api_key": "x"}})
+    except ValueError as e:  # pragma: no cover - only if the alias regresses
+        assert "Unsupported LLM provider" not in str(e)
+    except Exception:
+        # ImportError (missing SDK) or similar is fine: the alias resolved.
+        pass


### PR DESCRIPTION
### What
`HB_PROVIDER=anthropic` currently fails with `Unsupported LLM provider: anthropic`, even though the README and the `[engine]` extra both describe an **"Anthropic"** provider, and `anthropic` is the natural value (it matches the PyPI package name). Only the internal name `claude` was accepted.

This maps `anthropic` → `claude` via a small alias table in `humanbound_cli/engine/llm/__init__.py`.

### Why
First-5-minutes papercut: a user reading "OpenAI / Anthropic / Gemini providers" naturally sets `HB_PROVIDER=anthropic` and hits a hard error.

### Test
Adds `tests/unit/test_llm_pinger.py` — verifies the alias mapping, that unsupported providers still raise a clear error, and that `anthropic` is no longer rejected as unsupported. Full suite stays green.

Fixes #53

---
_Opened after a chat with Sofia — happy to adjust naming/approach if you'd rather handle aliases differently._ 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)