### PR TITLE
Tolerate bot configs without `headers`/`payload` (refs #51)

### DIFF
--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -386,8 +386,8 @@ class Bot(ResponseExtractor):
             messages, exec_t, _ = self.__make_api_call(
                 base_payload,
                 self.bot_config["chat_completion"]["endpoint"],
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
+                copy.deepcopy(self.bot_config["chat_completion"].get("headers", {})),
+                copy.deepcopy(self.bot_config["chat_completion"].get("payload", {})),
                 u_prompt,
                 conversation,
             )
@@ -456,11 +456,11 @@ class Bot(ResponseExtractor):
                 self.bot_config["chat_completion"]["endpoint"], base_payload
             )
             headers = self.__prepare_headers(
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
+                copy.deepcopy(self.bot_config["chat_completion"].get("headers", {})),
                 base_payload,
             )
             payload = self.__prepare_payload(
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
+                copy.deepcopy(self.bot_config["chat_completion"].get("payload", {})),
                 base_payload,
                 u_prompt,
                 conversation,
@@ -518,12 +518,12 @@ class Bot(ResponseExtractor):
                 self.bot_config["chat_completion"]["endpoint"], base_payload
             )
             headers = self.__prepare_headers(
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
+                copy.deepcopy(self.bot_config["chat_completion"].get("headers", {})),
                 base_payload,
             )
             headers.setdefault("user-agent", SSE_DEFAULT_USER_AGENT)
             payload = self.__prepare_payload(
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
+                copy.deepcopy(self.bot_config["chat_completion"].get("payload", {})),
                 base_payload,
                 u_prompt,
                 conversation,

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -419,6 +419,21 @@ def test_ping_non_streaming_with_string_response(bot):
     assert resp == "plain text response"
 
 
+def test_ping_non_streaming_without_headers_or_payload():
+    # A chat_completion block with only an endpoint (no `headers`/`payload`) is a
+    # natural shape for a no-auth agent. It must not crash with KeyError; the
+    # engine should default both to {}. Regression test for #51.
+    bot = Bot({"chat_completion": {"endpoint": "https://agent.example/chat"}}, "exp-abc")
+    with patch("humanbound_cli.engine.bot.requests.post") as post:
+        post.return_value = _mock_post(payload={"content": "agent says hi"})
+        resp, _, *_ = asyncio.run(bot.ping({}, "user prompt"))
+        sent = post.call_args.kwargs["json"]
+    assert resp == "agent says hi"
+    # With no `$PROMPT` placeholder and an empty payload, the engine falls back to
+    # the OpenAI-style messages array.
+    assert sent["messages"][-1] == {"role": "user", "content": "user prompt"}
+
+
 # ────────────────────────────────────────────────────────────────
 # Telemetry — smoke coverage
 # ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### What
A `chat_completion` block with only an `endpoint` (no `headers`, no `payload`) — a natural shape for a no-auth agent — crashed **every** conversation with `KeyError: 'headers'`:

```
File ".../engine/bot.py", line 389, in __chat
    copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
KeyError: 'headers'
```

This PR defaults `headers` and `payload` to `{}` via `.get(...)` in all three request paths (`__chat`, `__stream`, `__stream_sse`), matching how `thread_init` / `thread_auth` already treat their optional sub-keys.

### Verified
- Repro'd the original crash, then confirmed a headers/payload-less config now completes end-to-end (falls back to the OpenAI-style `messages` array, as documented in the README).
- New regression test in `tests/unit/test_engine_bot.py`; full suite green.

### Scope note
This fixes the **crash** half of #51. The **reporting** half — a run where 100% of conversations error still surfaces as `Finished / Pass 0 / Fail 0` — is the more important UX issue for a security tool and is left for a separate change, since it touches the presenter/summary and deserves its own discussion (e.g. an explicit `errored` count and a non-green status). Happy to take that on too if you point me at where you'd want the error surfaced. Hence **Refs** rather than **Fixes** #51.

---
_From the same first-run pass I mentioned to Sofia._ 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)