### PR TITLE
Skip docs-hook tests when mkdocs isn't installed (fixes #54)

### DIFF
--- a/tests/unit/test_docs_hooks_lint.py
+++ b/tests/unit/test_docs_hooks_lint.py
@@ -3,8 +3,13 @@
 import logging
 from types import SimpleNamespace
 
-import lint
 import pytest
+
+# The docs hooks import `mkdocs` at module load; it only ships in the `[dev]`
+# extra. Skip (don't error) when it's absent so `pytest` works on a plain install.
+pytest.importorskip("mkdocs")
+
+import lint
 from mkdocs.exceptions import PluginError
 
 

--- a/tests/unit/test_docs_hooks_llms_txt.py
+++ b/tests/unit/test_docs_hooks_llms_txt.py
@@ -2,6 +2,12 @@
 
 from types import SimpleNamespace
 
+import pytest
+
+# The docs hooks import `mkdocs` at module load; it only ships in the `[dev]`
+# extra. Skip (don't error) when it's absent so `pytest` works on a plain install.
+pytest.importorskip("mkdocs")
+
 import llms_txt
 
 

--- a/tests/unit/test_docs_hooks_schema.py
+++ b/tests/unit/test_docs_hooks_schema.py
@@ -3,6 +3,11 @@
 from types import SimpleNamespace
 
 import pytest
+
+# The docs hooks import `mkdocs` at module load; it only ships in the `[dev]`
+# extra. Skip (don't error) when it's absent so `pytest` works on a plain install.
+pytest.importorskip("mkdocs")
+
 import schema  # docs/hooks/schema.py via conftest sys.path injection
 
 


### PR DESCRIPTION
### What
After a plain `pip install -e .`, running `pytest` dies at **collection** with 3 errors, because the docs-hook test modules import `mkdocs` (only in the `[dev]` extra). This aborts the whole suite before any of the 700+ real tests run:

```
ERROR tests/unit/test_docs_hooks_schema.py  - ModuleNotFoundError: No module named 'mkdocs'
ERROR tests/unit/test_docs_hooks_llms_txt.py
ERROR tests/unit/test_docs_hooks_lint.py
!!! Interrupted: 3 errors during collection !!!
```

### Fix
Guard the three affected modules with `pytest.importorskip("mkdocs")`. They skip cleanly when `mkdocs` is absent and still run under `[dev]` / CI.

### Verified
- Without `mkdocs`: `811 passed, 3 skipped` (was: interrupted at collection).
- With `mkdocs` installed: the three files run normally (79 tests).
- `ruff check` clean on the edited files.

Fixes #54

---
_Small contributor-experience fix from my first run-through._ 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)