### PR TITLE
Make Ollama air-gap mode work on a core install (no openai SDK) — fixes #52

### DIFF
--- a/humanbound_cli/engine/llm/ollama.py
+++ b/humanbound_cli/engine/llm/ollama.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024-2026 Humanbound
-"""Ollama LLM pinger — OpenAI-compatible client for local ollama.
+"""Ollama LLM pinger — talks to a local Ollama over its OpenAI-compatible API.
 
-Ollama exposes an OpenAI-compatible API at /v1/chat/completions.
+Ollama exposes an OpenAI-compatible endpoint at /v1/chat/completions.
 No API key required. Full local isolation — zero external network calls.
+
+This provider deliberately uses `httpx` (a core dependency) rather than the
+`openai` SDK, so the air-gapped path works on a plain `pip install humanbound`
+without the `[engine]` extra.
 
 Usage:
     provider = {"name": "ollama", "integration": {"model": "llama3.1:8b"}}
@@ -13,6 +17,8 @@ Usage:
 
 import time
 from os import getenv
+
+import httpx
 
 ALLOWED_MAX_OUT_TOKENS = 4096
 DEFAULT_MAX_OUT_TOKENS = 2048
@@ -33,13 +39,7 @@ class LLMPinger:
         integration = model_provider.get("integration", {})
         self.model = integration.get("model", getenv("HB_MODEL", "llama3.1:8b"))
         self.endpoint = integration.get("endpoint", getenv("HB_ENDPOINT", DEFAULT_OLLAMA_ENDPOINT))
-
-        from openai import OpenAI
-
-        self._client = OpenAI(
-            base_url=f"{self.endpoint}/v1",
-            api_key="ollama",  # ollama doesn't need a key but the SDK requires one
-        )
+        self._url = f"{self.endpoint.rstrip('/')}/v1/chat/completions"
 
     def ping(
         self,
@@ -51,22 +51,38 @@ class LLMPinger:
         retry_counter = 0
         max_tokens = min(max_tokens, ALLOWED_MAX_OUT_TOKENS)
 
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_p},
+                {"role": "user", "content": user_p},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+
         while retry_counter <= MAX_RETRY_COUNTER:
             try:
-                response = self._client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_p},
-                        {"role": "user", "content": user_p},
-                    ],
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    timeout=LLM_PING_TIMEOUT,
-                )
-                content = response.choices[0].message.content
+                resp = httpx.post(self._url, json=body, timeout=LLM_PING_TIMEOUT)
+                if resp.status_code == 429:
+                    retry_counter += 1
+                    if retry_counter <= MAX_RETRY_COUNTER:
+                        time.sleep(retry_counter)
+                        continue
+                    raise Exception("502/Rate limit error.")
+                resp.raise_for_status()
+                data = resp.json()
+                content = data["choices"][0]["message"].get("content")
                 if content is None:
                     return "[No content in LLM response]"
                 return content
+            except httpx.ConnectError:
+                raise Exception(
+                    f"Cannot connect to ollama at {self.endpoint}. "
+                    f"Is ollama running? Start it with: ollama serve"
+                )
+            except httpx.HTTPStatusError as e:
+                raise Exception(f"502/Error while pinging ollama - {e.response.status_code}")
             except Exception as e:
                 if "rate" in str(e).lower() or "429" in str(e):
                     retry_counter += 1
@@ -74,9 +90,4 @@ class LLMPinger:
                         time.sleep(retry_counter)
                         continue
                     raise Exception("502/Rate limit error.")
-                if "connection" in str(e).lower():
-                    raise Exception(
-                        f"Cannot connect to ollama at {self.endpoint}. "
-                        f"Is ollama running? Start it with: ollama serve"
-                    )
                 raise Exception(f"502/Error while pinging ollama - {str(e)}")

--- a/tests/unit/test_ollama_pinger.py
+++ b/tests/unit/test_ollama_pinger.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Tests for the Ollama pinger. It must talk to Ollama over httpx (a core dep),
+so the air-gapped path works without the `[engine]` extra / the openai SDK."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from humanbound_cli.engine.llm.ollama import LLMPinger
+
+
+def test_builds_openai_compatible_url():
+    p = LLMPinger({"integration": {"model": "m", "endpoint": "http://host:1234/"}})
+    assert p._url == "http://host:1234/v1/chat/completions"
+
+
+def test_ping_parses_content_and_sends_expected_body():
+    p = LLMPinger({"integration": {"model": "llama3.1:8b", "endpoint": "http://host:1234"}})
+    fake = MagicMock(status_code=200)
+    fake.json.return_value = {"choices": [{"message": {"content": "hello"}}]}
+    fake.raise_for_status.return_value = None
+    with patch("humanbound_cli.engine.llm.ollama.httpx.post", return_value=fake) as post:
+        out = p.ping("system prompt", "user prompt", max_tokens=128, temperature=0)
+    assert out == "hello"
+    body = post.call_args.kwargs["json"]
+    assert body["model"] == "llama3.1:8b"
+    assert body["messages"][0] == {"role": "system", "content": "system prompt"}
+    assert body["messages"][1] == {"role": "user", "content": "user prompt"}
+
+
+def test_ping_none_content_returns_placeholder():
+    p = LLMPinger({"integration": {"model": "m", "endpoint": "http://host:1"}})
+    fake = MagicMock(status_code=200)
+    fake.json.return_value = {"choices": [{"message": {"content": None}}]}
+    fake.raise_for_status.return_value = None
+    with patch("humanbound_cli.engine.llm.ollama.httpx.post", return_value=fake):
+        assert p.ping("s", "u") == "[No content in LLM response]"
+
+
+def test_ping_connection_error_is_actionable():
+    p = LLMPinger({"integration": {"model": "m", "endpoint": "http://host:1"}})
+    with patch(
+        "humanbound_cli.engine.llm.ollama.httpx.post",
+        side_effect=httpx.ConnectError("refused"),
+    ):
+        with pytest.raises(Exception, match="Is ollama running"):
+            p.ping("s", "u")


### PR DESCRIPTION
### What
The README advertises Ollama as *"Full air-gap … zero external API calls"* with `pip install humanbound`. But on a **core-only install**, `HB_PROVIDER=ollama` failed immediately:

```
Local test failed: No module named 'openai'
```

because `humanbound_cli/engine/llm/ollama.py` did `from openai import OpenAI`, and `openai` only ships in the `[engine]` extra.

### Fix
Talk to Ollama's OpenAI-compatible `/v1/chat/completions` endpoint over **`httpx`** (already a core dependency) instead of the OpenAI SDK. Behavior is preserved — same retry-on-429, same timeout, same actionable *"Is ollama running?"* message — but the air-gap path no longer needs `[engine]`.

### Verified
In a **fresh core-only venv** (confirmed `openai` is *not* installed), the pinger reaches a mock Ollama and returns a completion:
```
openai installé: False
Réponse Ollama (core-only, sans openai): '1'
```
The old code raised `ModuleNotFoundError` in that exact environment.

New unit tests in `tests/unit/test_ollama_pinger.py` (URL construction, body shape, `None`-content handling, connection-error message). Full suite green; `ruff` clean.

> Note: this is the same class of bug as the `httpx` one fixed in 2.6.0 — a dependency from an optional extra reached at import time. If you'd rather keep the OpenAI SDK and instead adjust the README, happy to flip the approach — but the httpx route keeps air-gap genuinely dependency-light.

Fixes #52

---
_From the first-run pass I mentioned to Sofia._ 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)