### PR TITLE
Don't report an all-errored run as a pass (refs #51)

### DIFF
--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -576,7 +576,7 @@ def test_command(
             _findings_seen = 0
 
         # Display results (same rendering, canonical shapes)
-        _display_results(result, posture)
+        all_errored = _display_results(result, posture)
 
         # Next suggestions — vary by mode
         if is_platform:
@@ -597,6 +597,15 @@ def test_command(
                     ("hb guardrails -o rules.yaml", "Export firewall rules"),
                 ]
             )
+
+        # A run where every conversation errored is a scan failure, not a pass.
+        # Fail the command so CI can't misread it as green — independent of
+        # --fail-on, which only inspects insight severity and sees nothing here.
+        if all_errored:
+            console.print(
+                "\n[red]No conversations completed — treating this run as a failure.[/red]"
+            )
+            raise SystemExit(1)
 
         # Check fail-on condition
         if fail_on:
@@ -827,11 +836,28 @@ def _wait_verbose(runner, experiment_id: str) -> str:
     return status.status
 
 
-def _display_results(result: TestResult, posture: Posture):
+def _all_errored(stats: dict) -> bool:
+    """True when the run produced conversations but none completed — i.e. every
+    conversation errored (0 pass, 0 fail, >0 error).
+
+    Such a run carries no security signal at all and must not be presented as a
+    pass: "Pass: 0 / Fail: 0" on a fully-errored run reads as "my agent is clean"
+    when in fact nothing was actually tested.
+    """
+    total = stats.get("total", 0) or 0
+    completed = (stats.get("pass", 0) or 0) + (stats.get("fail", 0) or 0)
+    errored = stats.get("error", 0) or 0
+    return total > 0 and completed == 0 and errored > 0
+
+
+def _display_results(result: TestResult, posture: Posture) -> bool:
     """Display experiment results with posture grade and findings summary.
 
     Uses canonical TestResult and Posture shapes — works identically
     for both platform and local runners.
+
+    Returns True when every conversation errored (see ``_all_errored``), so the
+    caller can exit non-zero instead of treating the run as a pass.
     """
     status = result.status
     status_color = {
@@ -841,6 +867,13 @@ def _display_results(result: TestResult, posture: Posture):
     }.get(status, "white")
 
     stats = result.stats
+    errored = stats.get("error", 0) or 0
+    all_errored = _all_errored(stats)
+
+    # A run where every conversation errored produced no security signal — don't
+    # paint it green, and don't let "Pass: 0 / Fail: 0" read as a clean pass.
+    if all_errored:
+        status_color = "red"
 
     # Build results panel content
     panel_lines = [
@@ -850,6 +883,17 @@ def _display_results(result: TestResult, posture: Posture):
         f"  [green]Pass:[/green] {stats.get('pass', 0)}",
         f"  [red]Fail:[/red] {stats.get('fail', 0)}",
     ]
+    if errored:
+        panel_lines.append(f"  [yellow]Errored:[/yellow] {errored}")
+
+    if all_errored:
+        panel_lines.append("")
+        panel_lines.append("[red bold]⚠ No conversations completed — every one errored.[/red bold]")
+        panel_lines.append(
+            "[red]This is NOT a passing result. Check the agent endpoint/config and "
+            "connectivity, then re-run.[/red]"
+        )
+        panel_lines.append("[dim]Inspect the failures with: hb logs[/dim]")
 
     # Posture grade (available from both runners)
     if posture.grade is not None:
@@ -879,8 +923,9 @@ def _display_results(result: TestResult, posture: Posture):
         )
         panel_lines.append(f"[dim]Previously: {posture.previous_grade}{prev_score_str}[/dim]")
 
+    panel_title = "Experiment Complete — no results" if all_errored else "Experiment Complete"
     console.print(
-        Panel("\n".join(panel_lines), title="Experiment Complete", border_style=status_color)
+        Panel("\n".join(panel_lines), title=panel_title, border_style=status_color)
     )
 
     # Show insights if available
@@ -903,6 +948,8 @@ def _display_results(result: TestResult, posture: Posture):
             console.print(
                 f"  {i}. [{severity_color}]{severity_str.upper()}[/{severity_color}]: {insight.get('explanation', '')}"
             )
+
+    return all_errored
 
 
 def _severity_label(severity) -> str:

--- a/tests/unit/test_errored_run_reporting.py
+++ b/tests/unit/test_errored_run_reporting.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""A run where every conversation errored carries no security signal and must
+not be reported as a pass. Covers `_all_errored` and `_display_results`."""
+
+import io
+
+import pytest
+from rich.console import Console
+
+import humanbound_cli.commands.test as test_cmd
+from humanbound_cli.commands.test import _all_errored, _display_results
+from humanbound_cli.engine.runner import Posture
+from humanbound_cli.engine.runner import TestResult as _TestResult
+
+
+@pytest.mark.parametrize(
+    "stats,expected",
+    [
+        ({"total": 3, "pass": 0, "fail": 0, "error": 3}, True),  # everything errored
+        ({"total": 5, "pass": 2, "fail": 0, "error": 3}, False),  # some completed
+        ({"total": 5, "pass": 0, "fail": 1, "error": 4}, False),  # a fail counts as signal
+        ({"total": 0, "pass": 0, "fail": 0, "error": 0}, False),  # empty run, different case
+        ({"total": 3, "pass": 3, "fail": 0, "error": 0}, False),  # clean pass
+        ({"total": 3, "pass": 0, "fail": 0}, False),  # no error key at all
+    ],
+)
+def test_all_errored_truth_table(stats, expected):
+    assert _all_errored(stats) is expected
+
+
+def _capture(result, posture):
+    """Render _display_results into a string, returning (all_errored, output)."""
+    buf = io.StringIO()
+    original = test_cmd.console
+    test_cmd.console = Console(file=buf, force_terminal=False, width=100)
+    try:
+        flag = _display_results(result, posture)
+    finally:
+        test_cmd.console = original
+    return flag, buf.getvalue()
+
+
+def test_display_flags_and_warns_when_all_errored():
+    result = _TestResult(
+        experiment_id="exp-1",
+        name="t",
+        status="Finished",
+        stats={"total": 3, "pass": 0, "fail": 0, "error": 3},
+    )
+    flag, out = _capture(result, Posture())
+    assert flag is True
+    assert "Errored" in out
+    assert "No conversations completed" in out
+    assert "NOT a passing result" in out
+
+
+def test_display_does_not_warn_on_a_normal_pass():
+    result = _TestResult(
+        experiment_id="exp-2",
+        name="t",
+        status="Finished",
+        stats={"total": 3, "pass": 3, "fail": 0, "error": 0},
+    )
+    flag, out = _capture(result, Posture(overall_score=100.0, grade="A"))
+    assert flag is False
+    assert "No conversations completed" not in out


### PR DESCRIPTION
### What
This is the **reporting** half of #51 (the crash half is #57).

When every conversation errored (0 pass, 0 fail, N errors), `hb test` still printed a green panel:

```
Experiment Complete
  Total logs: 97
  Pass: 0
  Fail: 0
```
…and exited **0**. For a security scanner, an all-errored run that reads as "clean" is the dangerous failure mode — a user (or CI) sees `0 fail` and ships.

### After
```
Experiment Complete — no results
  Total logs: 97
  Pass: 0
  Fail: 0
  Errored: 97
⚠ No conversations completed — every one errored.
This is NOT a passing result. Check the agent endpoint/config and connectivity, then re-run.
→ exit code 1
```

- Adds an `Errored: N` line whenever there are errors.
- When **nothing** completed, paints the panel red, shows an explicit warning, and **exits non-zero** — independent of `--fail-on` (which inspects insight severity and sees nothing when all errored).
- Partial errors (some conversations completed) are shown but don't fail the run.

### How
`_display_results` now returns an `all_errored` flag (via a small pure `_all_errored(stats)` helper); the command exits 1 on it.

### Verified
- Unit tests: `_all_errored` truth table + rendering/return behavior.
- End-to-end: reproduced a fully-errored run (97/97) — it now prints the warning and exits 1 (was: green panel, exit 0). Full suite green; `ruff` clean.

Refs #51 (pairs with #57)

---
_The follow-up I promised on the reporting side._ 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)