### PR TITLE
feat(telemetry): IP geolocation, account email, and dev-install opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Telemetry: IP-based geolocation.** CLI and docs-site analytics now derive an
+  approximate location (country, region, city, and coarse coordinates) from the
+  request IP via PostHog GeoIP enrichment; the raw IP is discarded after
+  enrichment and never stored. Docs-site geolocation is gated on Analytics
+  consent; the CLI follows the existing opt-out model and applies to pre- and
+  post-login events.
+- **Telemetry: account email on logged-in CLI events.** After `hb login`, the
+  account email is attached as a PostHog person property to measure CLI→Platform
+  conversion. Anonymous (pre-login) events never carry an email.
+- `NOTICE` file per Apache-2.0 section 4(d).
+
 ### Changed
+- `PRIVACY.md` documents the IP-derived approximate location and email person
+  property, corrects the analytics retention period to **1 year**, and adds an
+  honest note that `hb logout` does not re-anonymize prior events.
 - **Contribution policy: CLA replaced by DCO.** External contributions no
   longer require signing the Humanbound Contributor License Agreement.
   Contributions are now accepted under the Developer Certificate of Origin
@@ -19,8 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code must be permissively licensed (Apache-2.0/MIT/BSD/ISC); GPL, AGPL,
   SSPL, and BSL code cannot be accepted.
 
-### Added
-- `NOTICE` file per Apache-2.0 section 4(d).
+### Fixed
+- Telemetry is now auto-disabled on **editable / source-checkout installs**
+  (`pip install -e .`); previously only `HUMANBOUND_DEV=1` disabled development
+  runs.
 
 ## [2.6.0] — 2026-07-09
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,17 +34,18 @@ This document does **NOT** cover:
 
 ## TL;DR
 
-- Telemetry is **on by default**. Before you log in, events carry only an
-  anonymous machine UUID and no personal data.
-- **After you log in** with `hb login`, events are associated with an opaque
-  user identifier (your Auth0 `sub`) so we can measure CLI→Platform
-  conversion.
+- Telemetry is **on by default**. Before you log in, events carry an
+  anonymous machine UUID and your IP address — used only to derive an
+  approximate location (country, region, city, and coarse coordinates); the IP
+  itself is not stored.
+- **After you log in** with `hb login`, events are tied to an opaque user
+  identifier (your Auth0 `sub`), and your account **email** is attached as a
+  person property.
 - Disable with `hb telemetry disable`, `HB_TELEMETRY_DISABLED=1`, or
   `DO_NOT_TRACK=1`.
 - Automatically disabled in CI, editable dev installs, and when stdout is
   piped (non-TTY).
-- Data goes to PostHog EU Cloud (Frankfurt region) and is retained for
-  24 months.
+- Data goes to PostHog EU Cloud and is retained for 1 year.
 
 ## What we collect
 
@@ -58,16 +59,25 @@ Every event includes these baseline properties that we set explicitly:
 | `distinct_id` | `tlm_<uuid>` / `auth0\|abc123` | Anonymous machine ID until you log in, then a stable opaque identifier so events can be attributed to your Humanbound account |
 
 In addition, the PostHog Python client library automatically attaches a small
-set of properties to every event it sends. These are technical metadata only —
-no personal data — and include:
+set of properties to every event it sends. Most are technical metadata; one
+is a derived, approximate location:
 
 - `$os`, `$os_version` (e.g. `Mac OS X`, `15.5`)
 - `$python_version`, `$python_runtime` (e.g. `3.12.10`, `CPython`)
 - `$lib`, `$lib_version` (always `posthog-python` plus the SDK version)
-- `$geoip_disable: true` — PostHog's server-side IP geolocation is disabled on our project
+- `$geoip_*` — an approximate location PostHog derives from the request's source
+  IP at ingestion: country, region, and city, plus coarse map coordinates and
+  related fields, accurate only to roughly city level. PostHog discards the raw
+  IP ("Discard client IP data"). Applies to every event while telemetry is
+  enabled, including before login.
 
 We do not have ability to opt out of these PostHog-attached properties individually;
 disabling telemetry entirely (see below) stops all of them.
+
+For events sent **while you're logged in**, we additionally attach your
+account **email** as a PostHog person property (`$set: { email }`), read
+locally from `~/.humanbound/credentials.json`. Anonymous, pre-login events
+never carry an email.
 
 The seven events:
 
@@ -85,33 +95,42 @@ The seven events:
 
 We explicitly **do not** send:
 
-- Hostnames, OS usernames, IP addresses (PostHog disables server-side IP
-  geolocation on our project)
+- Hostnames, OS usernames
 - File paths, repository paths, endpoint URLs, API base URLs
 - Test prompts, model responses, finding text, configuration file contents
 - Environment variable *values* (we only check the *presence* of CI sentinels)
 - Authentication tokens, API keys, or refresh tokens
 - Names, organization names, billing details
-- Your email address
+
+Your IP address is used transiently for geolocation but **not stored** — see
+[What we collect](#what-we-collect).
 
 ## Identity
 
 **Before you log in:** every event carries an anonymous machine UUID stored
 in `~/.humanbound/telemetry.json` (mode 0600). Different machines get
-different UUIDs. No personal data is associated with the UUID — it's a fresh
-random value generated locally on first run.
+different UUIDs. While telemetry is enabled, each event's source IP is used
+transiently for geolocation (see [What we collect](#what-we-collect)); the IP
+is not stored or linked to the UUID.
 
 **When you run `hb login` successfully:** we send PostHog's `$identify` call
 to associate the prior anonymous UUID with an **opaque user identifier**
-(your Auth0 `sub`, e.g. `auth0|abc123`). From that point on, telemetry events
-from your machine are tagged with this opaque identifier instead of the
-anonymous UUID. PostHog stitches the prior anonymous timeline to your account
-so we can measure CLI→Platform conversion.
+(your Auth0 `sub`, e.g. `auth0|abc123`), and subsequent events attach your
+account email as a person property (`$set: { email }`). From that point on,
+telemetry events from your machine are tagged with this opaque identifier
+instead of the anonymous UUID. PostHog stitches the prior anonymous timeline
+to your account so we can measure CLI→Platform conversion.
 
 If you'd rather not associate telemetry events with your account at all, the
 supported path is to **not log in to the CLI**. Local mode (`hb test --local`,
 basic `hb posture`, etc.) works without login and never associates events
 with your account.
+
+**Logging out:** `hb logout` reverts the CLI to the anonymous machine UUID,
+but this is **not** re-anonymization — login permanently aliases that UUID to
+your account in PostHog and stores your email as a person property, so events
+from this machine stay associated with your account. The UUID is not reset on
+logout.
 
 ## How to disable
 
@@ -149,8 +168,7 @@ any of:
 ## Data destination and retention
 
 - Destination: PostHog EU Cloud, region Frankfurt (`eu.i.posthog.com`)
-- Retention: **24 months** from event ingestion. Events older than this are
-  deleted from PostHog automatically per our project's retention configuration.
+- Retention: **1 year** from event ingestion.
 
 ## Sub-processors
 
@@ -158,7 +176,7 @@ We share data with the following third-party processors:
 
 | Processor | Purpose | Location | Terms |
 |---|---|---|---|
-| PostHog | Product analytics ingestion and dashboard | EU (Frankfurt) | [posthog.com/terms](https://posthog.com/terms), [posthog.com/dpa](https://posthog.com/dpa) |
+| PostHog | Product analytics; receives the request IP for geolocation (discarded after deriving an approximate location) and, for logged-in CLI users, the account email | EU (Frankfurt) | [posthog.com/terms](https://posthog.com/terms), [posthog.com/dpa](https://posthog.com/dpa) |
 | Reddit | Advertising measurement, docs site (with advertising consent) | United States | [Advertising Data Processing Agreement](https://business.reddithelp.com/s/article/Reddit-Advertising-Data-Processing-Agreement) |
 
 PostHog acts as a Data Processor under GDPR Art. 28. Our use of PostHog is
@@ -176,21 +194,22 @@ by the international-transfer terms in Reddit's
 
 The documentation site (`docs.humanbound.ai`) sends **anonymous** web analytics
 to the same PostHog project as the CLI. There is no login on the docs site, so
-nothing is tied to an account and no personal data is collected.
+nothing is ever tied to an account, an email, or a name.
 
 - **Cookieless by default:** until you accept **Analytics** in the cookie
   banner, PostHog stores nothing on your device — no cookies, no local storage —
-  and each visit is a fresh anonymous session.
-- **With consent:** if you accept, we keep a first-party identifier in your
-  browser's local storage to recognize returning visits. You can change or
-  withdraw your choice anytime via the banner.
-- **What we collect:** page views and traffic source only, tagged `source: docs`.
-  Autocapture is off, so individual clicks and form inputs are never captured.
-- **No IP storage** *(in this analytics)***:** your IP address is never recorded
-  as an event property (`ip: false`, with `$ip`/`$ip_address` on a denylist) and
-  server-side IP geolocation is disabled (`$geoip_disable`), so it is neither
-  stored nor used to locate you. *(The optional advertising pixel below is
-  different — see Advertising.)*
+  and each visit is a fresh anonymous session. Your IP address is never
+  recorded as an event property (`ip: false`, with `$ip`/`$ip_address` on a
+  denylist) and server-side IP geolocation is disabled (`$geoip_disable: true`).
+- **With consent:** we keep a first-party identifier in your browser's local
+  storage to recognize returning visits, and PostHog derives an approximate
+  location from your IP, then discards it (as in
+  [What we collect](#what-we-collect)). Withdraw anytime via the banner to
+  return to the cookieless, IP-free behavior above.
+- **What we collect:** page views and traffic source only, tagged `source: docs`,
+  plus derived location once you've consented (see above). Autocapture is off,
+  so individual clicks and form inputs are never captured. *(The optional
+  advertising pixel below is different — see Advertising.)*
 - **Do Not Track:** if your browser sends a `DNT` signal, no analytics are sent.
 - **Region & processor:** PostHog EU Cloud (Frankfurt) — same processor and DPA
   as [Sub-processors](#sub-processors) above.

--- a/docs/overrides/partials/posthog.html
+++ b/docs/overrides/partials/posthog.html
@@ -7,6 +7,7 @@
   var consent = (typeof __md_get === "function") ? __md_get("__consent") : null;
   var analyticsConsent = !!(consent && consent.analytics);
 
+  var ipEnabled = analyticsConsent;   // IP is personal data → collect only with consent
   posthog.init({{ config.extra.posthog.api_key | tojson }}, {
     api_host: {{ config.extra.posthog.host | tojson }},
     persistence: analyticsConsent ? 'localStorage' : 'memory',
@@ -14,12 +15,12 @@
     respect_dnt: true,
     capture_pageview: false,
     autocapture: false,
-    ip: false,
-    property_denylist: ['$ip', '$ip_address'],
+    ip: ipEnabled,
+    property_denylist: ipEnabled ? [] : ['$ip', '$ip_address'],
   });
   // No consent: clear any persistent id from a prior consented visit.
   if (!analyticsConsent) { posthog.reset(); }
-  posthog.register({ source: 'docs', $geoip_disable: true });
+  posthog.register({ source: 'docs', $geoip_disable: !ipEnabled });
 
   // capture_pageview is off; drive pageviews via document$ so navigation.instant
   // (XHR page swaps, no reload) is counted on every navigation.

--- a/humanbound_cli/telemetry/client.py
+++ b/humanbound_cli/telemetry/client.py
@@ -70,6 +70,17 @@ def _user_id_from_credentials() -> str | None:
         return None
 
 
+def _email_from_credentials() -> str | None:
+    """Return the account email persisted in credentials.json, or None."""
+    f = _credentials_file()
+    if not f.exists():
+        return None
+    try:
+        return json.loads(f.read_text()).get("email") or None
+    except Exception:
+        return None
+
+
 def _resolve_distinct_id() -> str:
     """Auth'd user id if available, else the anonymous machine UUID."""
     global _user_id
@@ -97,6 +108,9 @@ def _ensure_init() -> bool:
             _posthog.host = config.get_posthog_host()
             # Reasonable defaults; SDK handles batching + background flush.
             _posthog.disabled = False
+            # disable_geoip defaults to True in posthog-python; flip it off so
+            # PostHog derives country/region/city. Raw IP is discarded project-side.
+            _posthog.disable_geoip = False
             _initialized_ok = True
         except Exception:
             _initialized_ok = False
@@ -123,6 +137,10 @@ def capture(event: str, properties: dict | None = None) -> None:
         merged = baseline(is_authenticated=is_auth)
         if properties:
             merged.update(properties)
+        if is_auth:
+            email = _email_from_credentials()
+            if email:
+                merged["$set"] = {"email": email}
         _posthog.capture(
             distinct_id=distinct_id,
             event=event,

--- a/humanbound_cli/telemetry/consent.py
+++ b/humanbound_cli/telemetry/consent.py
@@ -56,6 +56,18 @@ def _write_state(state: dict) -> None:
     f.chmod(0o600)
 
 
+def _is_editable_install() -> bool:
+    """True when running from a source checkout (editable / dev install).
+
+    A wheel install lives under site-packages; a source checkout has the
+    project's pyproject.toml one level above the package. Fail open.
+    """
+    try:
+        return (Path(__file__).resolve().parents[2] / "pyproject.toml").is_file()
+    except Exception:
+        return False
+
+
 def _compute() -> tuple[bool, str | None]:
     """Return (enabled, reason_if_disabled). Order matters — first match wins."""
     if os.environ.get("DO_NOT_TRACK") == "1":
@@ -69,6 +81,8 @@ def _compute() -> tuple[bool, str | None]:
             return False, f"CI detected ({v})"
     if os.environ.get("HUMANBOUND_DEV") == "1":
         return False, "dev mode (HUMANBOUND_DEV=1)"
+    if _is_editable_install():
+        return False, "editable/development install"
     if not sys.stdout.isatty():
         return False, "non-TTY stdout"
     return True, None

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -50,6 +50,8 @@ def _isolate(monkeypatch, tmp_path):
         monkeypatch.delenv(v, raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    # Test suite runs from source; force non-editable so telemetry isn't auto-disabled.
+    monkeypatch.setattr(consent, "_is_editable_install", lambda: False)
     consent.reset_cache()
     client.reset_for_tests()
     yield
@@ -154,6 +156,12 @@ def test_consent_disabled_in_dev_mode(monkeypatch):
     monkeypatch.setenv("HUMANBOUND_DEV", "1")
     assert consent.is_enabled() is False
     assert "dev mode" in consent.disabled_reason()
+
+
+def test_consent_disabled_in_editable_install(monkeypatch):
+    monkeypatch.setattr(consent, "_is_editable_install", lambda: True)
+    assert consent.is_enabled() is False
+    assert "editable" in consent.disabled_reason()
 
 
 def test_consent_disabled_when_not_tty(monkeypatch):
@@ -334,6 +342,24 @@ def _write_credentials_with_user_id(tmp_path: Path, user_id: str | None) -> None
     creds.write_text(_json.dumps({"api_token": fake_jwt}))
 
 
+def _write_credentials_with_user_id_and_email(
+    tmp_path: Path, user_id: str, email: str | None
+) -> None:
+    """Fake credentials.json with a user_id-claim JWT plus a top-level email."""
+    import base64 as _b64
+    import json as _json
+
+    claims = {"sub": "m2m-app-id", "https://aiandme.io/user_id": user_id}
+    payload = _b64.urlsafe_b64encode(_json.dumps(claims).encode()).rstrip(b"=").decode()
+    fake_jwt = f"header.{payload}.sig"
+    creds = tmp_path / ".humanbound" / "credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    doc = {"api_token": fake_jwt}
+    if email is not None:
+        doc["email"] = email
+    creds.write_text(_json.dumps(doc))
+
+
 def test_identify_from_credentials_reads_user_id_claim(tmp_path, mock_posthog):
     _write_credentials_with_user_id(tmp_path, "auth0|user123")
     client.identify_from_credentials()
@@ -358,6 +384,34 @@ def test_capture_uses_user_id_from_credentials_when_present(tmp_path, mock_posth
     client.capture("posture_view", {"is_local": True})
     assert mock_posthog.capture.call_args.kwargs["distinct_id"] == "auth0|user123"
     assert mock_posthog.capture.call_args.kwargs["properties"]["is_authenticated"] is True
+
+
+def test_ensure_init_enables_geoip_enrichment(mock_posthog):
+    # capture() triggers _ensure_init(); geo enrichment must be turned on
+    # by flipping the SDK's disable_geoip default off.
+    client.capture("install")
+    assert mock_posthog.disable_geoip is False
+
+
+def test_capture_sets_email_person_property_when_authed(tmp_path, mock_posthog):
+    _write_credentials_with_user_id_and_email(tmp_path, "auth0|user123", "dev@example.com")
+    client.capture("test_start", {"test_level": "unit"})
+    props = mock_posthog.capture.call_args.kwargs["properties"]
+    assert props["is_authenticated"] is True
+    assert props["$set"] == {"email": "dev@example.com"}
+
+
+def test_capture_omits_email_when_anonymous(mock_posthog):
+    client.capture("install")
+    props = mock_posthog.capture.call_args.kwargs["properties"]
+    assert "$set" not in props
+
+
+def test_capture_omits_email_when_authed_but_no_email_stored(tmp_path, mock_posthog):
+    _write_credentials_with_user_id_and_email(tmp_path, "auth0|user123", None)
+    client.capture("test_start", {"test_level": "unit"})
+    props = mock_posthog.capture.call_args.kwargs["properties"]
+    assert "$set" not in props
 
 
 def test_shutdown_calls_flush_then_shutdown(mock_posthog):


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Adds IP-based geolocation and a logged-in account-email person property to the
CLI and docs-site telemetry, and makes editable/source installs opt out of
telemetry automatically.

- Approximate location (country, region, city, coarse coordinates) via PostHog
  GeoIP; raw IP discarded after enrichment (project-side), never stored.
- Docs site: consent-gated (Analytics). CLI: existing opt-out model.
- Email attached only for logged-in CLI users; anonymous events never carry it.
- Editable installs (pip install -e .) auto-disable telemetry.
- PRIVACY.md updated (location + email disclosure, retention corrected to 1 year,
  honest logout note).

Requires a one-time PostHog project config: "Discard client IP data" ON,
"Cookieless server hash mode" OFF.
## Type of change

- [x] New feature (non-breaking)
- [x] Documentation only  <!-- PRIVACY.md / docs-site partial -->

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
