### PR TITLE
feat(findings): regression retest + history (CLI + MCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SSPL, and BSL code cannot be accepted.
 
 ### Added
+- **Finding regression retest.** `hb findings retest <id>` replays a finding's
+  own recorded attacks against the current agent to check whether it is
+  actually fixed, reporting `still_vulnerable`, `not_reproduced`, or
+  `insufficient_evidence`. Fire-and-return by default (prints the experiment
+  id); `--watch` polls to completion and shows the outcome, and
+  `--testing-level unit|system|acceptance` (with `--deep`/`--full` shortcuts,
+  matching `hb test`) controls replay breadth.
+  `hb findings regressions <id>` lists a finding's retest history. Exposed to
+  agents via the `hb_retest_finding` and `hb_list_finding_regressions` MCP
+  tools.
 - `NOTICE` file per Apache-2.0 section 4(d).
 
 ## [2.6.0] — 2026-07-09

--- a/docs/docs/aisecops/findings.md
+++ b/docs/docs/aisecops/findings.md
@@ -6,6 +6,8 @@ keywords:
   - vulnerability tracking
   - finding delegation
   - regression detection
+  - regression retest
+  - hb findings retest
   - hb findings command
   - finding webhook events
   - severity weighted penalties
@@ -51,7 +53,41 @@ The lifecycle is automatic. When monitoring runs a new test cycle:
 - Findings seen again remain **open**
 - Findings not seen transition to **stale** after 14 days
 - Stale findings that reappear transition to **regressed**
-- Users can manually mark findings as **fixed**
+- Users can manually mark findings as **fixed** — and confirm that claim with a [regression retest](#verifying-a-fix)
+
+## Verifying a Fix
+
+Marking a finding **fixed** by hand is a claim; a **regression retest** checks it. `hb findings retest <id>` replays the finding's own recorded attacks against the *current* agent and reports whether the vulnerability is really gone:
+
+| Outcome | Meaning |
+|---|---|
+| `not_reproduced` | None of the replayed attacks fired again — evidence the fix holds. |
+| `still_vulnerable` | An attack fired again. The finding is automatically flipped **fixed → regressed**. |
+| `insufficient_evidence` | The finding has no replayable attack evidence, so nothing could be tested. Never treated as a pass. |
+
+A retest runs as a normal experiment (fire-and-poll): the command returns an experiment id immediately, or `--watch` waits and prints the outcome.
+
+**How much gets replayed** is controlled by `--testing-level`, using the same `unit` / `system` / `acceptance` ladder as [`hb test`](../testing/test-command.md):
+
+- `unit` (default) — replays the finding's **representative** attacks: a curated, deduplicated sample of the distinct ways it was triggered, so a retest is a fast, focused check rather than an exhaustive replay of every recorded conversation.
+- `system` / `acceptance` — add cluster samples around those representatives for broader coverage (`--deep` and `--full` are shortcuts, mirroring `hb test`).
+
+```bash
+# Fire a retest and get the experiment id back
+hb findings retest <finding-id>
+
+# Wait for the verdict
+hb findings retest <finding-id> --watch
+
+# Broader replay
+hb findings retest <finding-id> --full
+
+# See a finding's past retests
+hb findings regressions <finding-id>
+```
+
+!!! note "On-demand check"
+    Retesting is manual — it does not run automatically as part of monitoring. Use it once you believe a finding is fixed, then mark it **fixed** after a retest comes back `not_reproduced`.
 
 ## Team Delegation
 

--- a/docs/docs/integrations/mcp.md
+++ b/docs/docs/integrations/mcp.md
@@ -71,6 +71,7 @@ If your client launches with a minimal `PATH` and can't find `hb`, replace `"hb"
 |---|---|
 | `get_posture` | Current security posture score, grade, and trend data for the active project |
 | `get_findings` | List findings with optional status/severity filters |
+| `retest_finding` | Replay a finding's recorded attacks to verify whether it is fixed |
 | `get_coverage` | Test coverage summary and untested categories |
 | `get_experiments` | Recent experiments with status, results, and configuration |
 | `get_logs` | Conversation logs and verdicts from a specific experiment |
@@ -82,6 +83,7 @@ Once configured, you can ask your AI assistant questions like:
 
 - *"What's my current security posture score?"*
 - *"Show me all critical findings that are still open"*
+- *"Retest finding abc123 to check whether my fix holds"*
 - *"What attack categories haven't been tested yet?"*
 - *"Did the last experiment find any prompt injection vulnerabilities?"*
 - *"What ASCAM phase is my project currently in?"*

--- a/docs/docs/reference/commands.md
+++ b/docs/docs/reference/commands.md
@@ -86,6 +86,8 @@ The complete `hb` CLI reference, organised into eight categories: global flags, 
 | `hb findings` | List persistent vulnerability findings (--page, --size, -o \<file\>) |
 | `hb findings update <id>` | Update finding status or severity |
 | `hb findings assign <id>` | Assign finding to a team member |
+| `hb findings retest <id>` | Retest a finding to verify a fix (--testing-level unit\|system\|acceptance, --deep, --full, --watch) |
+| `hb findings regressions <id>` | Show a finding's regression-retest history |
 | `hb assessments` | List past security assessments |
 | `hb assessments show [id]` | View assessment detail (posture trajectory, drift, coverage, duration); defaults to the latest |
 | `hb assessments terminate [id]` | Stop a running assessment (defaults to the current/latest) |

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -1054,6 +1054,48 @@ class HumanboundClient:
         """Update a finding."""
         return self.put(f"projects/{project_id}/findings/{finding_id}", data=data)
 
+    def retest_finding(self, finding_id: str, testing_level: str = "unit") -> dict:
+        """Trigger a regression retest for a finding.
+
+        Replays the finding's own recorded attacks against the current agent to
+        verify whether it is actually fixed. Fire-and-poll: returns immediately
+        with the new experiment id; poll ``get_experiment_status`` and read the
+        outcome from the experiment ``results.regression`` on completion.
+
+        The route is top-level (``findings/{id}/retest``): the backend resolves
+        the project from the finding and authorizes on the organisation header,
+        so no project header is sent.
+
+        Args:
+            finding_id: Finding UUID.
+            testing_level: Replay breadth — 'unit' (representatives only),
+                'system' (+cluster samples), or 'acceptance' (+more).
+
+        Returns:
+            ``{"experiment_id": ..., "status": "running"}``.
+        """
+        return self.post(
+            f"findings/{finding_id}/retest",
+            data={"testing_level": testing_level},
+            include_project=False,
+        )
+
+    def list_finding_regressions(self, finding_id: str) -> list:
+        """List a finding's regression-retest history (newest first).
+
+        Top-level route (``findings/{id}/regressions``), org-scoped like
+        ``retest_finding``.
+
+        Args:
+            finding_id: Finding UUID.
+
+        Returns:
+            List of ``{experiment_id, outcome, partial, testing_level,
+            created_at}``; empty when the finding has never been retested.
+        """
+        response = self.get(f"findings/{finding_id}/regressions", include_project=False)
+        return response if isinstance(response, list) else response.get("data", response)
+
     # -------------------------------------------------------------------------
     # Experiment Extensions
     # -------------------------------------------------------------------------

--- a/humanbound_cli/commands/findings.py
+++ b/humanbound_cli/commands/findings.py
@@ -3,6 +3,7 @@
 """Findings commands."""
 
 import json
+import time
 
 import click
 from rich.console import Console
@@ -37,6 +38,16 @@ STATUS_STYLES = {
     "fixed": "[green]fixed[/green]",
 }
 
+# Regression retest outcomes (from the _regression harness).
+OUTCOME_STYLES = {
+    "still_vulnerable": "[red bold]still_vulnerable[/red bold]",
+    "not_reproduced": "[green]not_reproduced[/green]",
+    "insufficient_evidence": "[yellow]insufficient_evidence[/yellow]",
+}
+
+# Experiment statuses that end a run (mirrors experiments.py).
+TERMINAL_STATUSES = ["Finished", "Failed"]
+
 
 @click.group("findings", invoke_without_command=True)
 @click.option(
@@ -64,6 +75,8 @@ def findings_group(ctx, status, severity, page, size, as_json, output):
       hb findings -o findings.json       # Save to file
       hb findings update <id> --status fixed
       hb findings assign <id> --assignee <member-id>
+      hb findings retest <id>            # Verify a fix by replaying its attacks
+      hb findings regressions <id>       # Retest history
     """
     if ctx.invoked_subcommand is not None:
         return
@@ -253,6 +266,192 @@ def assign_finding(finding_id: str, assignee: str, delegation_status: str):
         console.print(f"[dim]ID: {finding_id}[/dim]")
         console.print(f"  Assignee: {assignee}")
         console.print(f"  Status: {delegation_status}")
+
+    except NotAuthenticatedError:
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+
+
+@findings_group.command("retest")
+@click.argument("finding_id")
+@click.option(
+    "--testing-level",
+    "-l",
+    type=click.Choice(["unit", "system", "acceptance"], case_sensitive=False),
+    default="unit",
+    help="Replay breadth: unit (representatives), system (+samples), acceptance (+more).",
+)
+@click.option("--deep", is_flag=True, default=False, help="Shortcut for --testing-level system.")
+@click.option(
+    "--full", is_flag=True, default=False, help="Shortcut for --testing-level acceptance."
+)
+@click.option(
+    "--watch", "-w", is_flag=True, help="Poll until the retest completes and show the outcome."
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def retest_finding(
+    finding_id: str, testing_level: str, deep: bool, full: bool, watch: bool, as_json: bool
+):
+    """Retest a finding to check whether it is actually fixed.
+
+    Replays the finding's own recorded attacks against the current agent. By
+    default this fires the retest and returns the experiment id; poll it with
+    'hb experiments status <id>' or pass --watch to wait for the outcome.
+
+    Testing levels mirror 'hb test': unit (representatives only), system and
+    acceptance add cluster samples for broader coverage.
+
+    FINDING_ID: Finding UUID (or partial ID).
+
+    \b
+    Examples:
+      hb findings retest abc123                       # Fire and return the experiment id
+      hb findings retest abc123 --watch               # Wait for the outcome
+      hb findings retest abc123 --full                # Broadest replay (acceptance)
+    """
+    # Shortcuts only apply when an explicit level wasn't given (matches hb test).
+    if deep and testing_level == "unit":
+        testing_level = "system"
+    elif full and testing_level == "unit":
+        testing_level = "acceptance"
+
+    client = HumanboundClient()
+
+    if not client.is_authenticated():
+        telemetry.fire_gated_command_hit()
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+
+    project_id = client.project_id
+    if not project_id:
+        console.print("[yellow]No project selected.[/yellow]")
+        console.print("Use 'hb projects use <id>' to select a project first.")
+        raise SystemExit(1)
+
+    try:
+        # Resolve partial ID (needs the project); the retest call is org-scoped.
+        finding_id = _resolve_finding_id(client, project_id, finding_id)
+
+        with console.status("Starting retest..."):
+            response = client.retest_finding(finding_id, testing_level=testing_level)
+
+        experiment_id = response.get("experiment_id") if isinstance(response, dict) else None
+
+        if not watch:
+            if as_json:
+                print(json.dumps(response, indent=2, default=str))
+                return
+            console.print("[green]Retest started.[/green]")
+            console.print(f"  Experiment: [dim]{experiment_id}[/dim]")
+            console.print(f"  Testing level: {testing_level}")
+            console.print(f"\n[dim]Poll with:[/dim] hb experiments status {experiment_id} --watch")
+            return
+
+        if not experiment_id:
+            console.print("[red]Error:[/red] retest did not return an experiment id.")
+            raise SystemExit(1)
+
+        # --watch: poll to completion, then read the outcome off the experiment.
+        with console.status("Retest running...") as spin:
+            while True:
+                status_resp = client.get_experiment_status(experiment_id)
+                current_status = (
+                    status_resp.get("status", "Unknown")
+                    if isinstance(status_resp, dict)
+                    else "Unknown"
+                )
+                spin.update(f"Retest running... ({current_status})")
+                if current_status in TERMINAL_STATUSES:
+                    break
+                time.sleep(15)
+
+        experiment = client.get_experiment(experiment_id)
+        results = experiment.get("results", {}) if isinstance(experiment, dict) else {}
+        regression = results.get("regression") or {}
+        outcome = regression.get("outcome")
+
+        if as_json:
+            print(json.dumps({"experiment_id": experiment_id, **regression}, indent=2, default=str))
+        else:
+            if current_status == "Failed":
+                console.print("[red]Retest experiment failed.[/red]")
+            elif outcome:
+                console.print(f"Outcome: {OUTCOME_STYLES.get(outcome, outcome)}")
+                if regression.get("partial"):
+                    console.print("[dim]  (partial — some vectors errored)[/dim]")
+            else:
+                console.print(
+                    "[yellow]Retest finished but no regression outcome was recorded.[/yellow]"
+                )
+
+        if current_status == "Failed" or outcome == "still_vulnerable":
+            raise SystemExit(1)
+
+    except NotAuthenticatedError:
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+
+
+@findings_group.command("regressions")
+@click.argument("finding_id")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def finding_regressions(finding_id: str, as_json: bool):
+    """Show a finding's regression-retest history (newest first).
+
+    FINDING_ID: Finding UUID (or partial ID).
+    """
+    client = HumanboundClient()
+
+    if not client.is_authenticated():
+        telemetry.fire_gated_command_hit()
+        console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
+        raise SystemExit(1)
+
+    project_id = client.project_id
+    if not project_id:
+        console.print("[yellow]No project selected.[/yellow]")
+        console.print("Use 'hb projects use <id>' to select a project first.")
+        raise SystemExit(1)
+
+    try:
+        finding_id = _resolve_finding_id(client, project_id, finding_id)
+
+        with console.status("Fetching retest history..."):
+            history = client.list_finding_regressions(finding_id)
+
+        if as_json:
+            print(json.dumps(history, indent=2, default=str))
+            return
+
+        if not history:
+            console.print("[yellow]This finding has never been retested.[/yellow]")
+            console.print(f"[dim]Run 'hb findings retest {finding_id}' to start one.[/dim]")
+            return
+
+        table = Table(title="Regression history")
+        table.add_column("Experiment", style="dim")
+        table.add_column("Outcome", width=22)
+        table.add_column("Partial", width=8)
+        table.add_column("Level", width=10)
+        table.add_column("Created", width=12)
+
+        for entry in history:
+            outcome = str(entry.get("outcome") or "")
+            table.add_row(
+                str(entry.get("experiment_id", "")),
+                OUTCOME_STYLES.get(outcome, outcome),
+                "yes" if entry.get("partial") else "",
+                str(entry.get("testing_level") or ""),
+                str(entry.get("created_at") or "")[:10],
+            )
+
+        console.print(table)
 
     except NotAuthenticatedError:
         console.print("[red]Not authenticated.[/red] Run 'hb login' first.")

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -660,6 +660,49 @@ def hb_update_finding(
         return _err(e)
 
 
+@mcp.tool()
+def hb_retest_finding(finding_id: str, testing_level: str = "unit") -> str:
+    """Retest a finding to verify whether it is actually fixed.
+
+    Replays the finding's OWN recorded attacks against the current agent and
+    reports an outcome: 'still_vulnerable', 'not_reproduced', or
+    'insufficient_evidence'.
+
+    Fire-and-poll: this returns immediately with the new experiment id.
+    Workflow: poll hb_get_experiment_status every 15-30 seconds until the
+    status is no longer 'Running', then call hb_get_experiment and read the
+    outcome from results.regression.
+
+    Args:
+        finding_id: Finding UUID.
+        testing_level: Replay breadth (same ladder as hb_run_test) — 'unit'
+            (representatives only), 'system' (+cluster samples), or
+            'acceptance' (+more).
+    """
+    try:
+        client = _get_client()
+        return _ok(client.retest_finding(finding_id, testing_level=testing_level))
+    except HumanboundError as e:
+        return _err(e)
+
+
+@mcp.tool()
+def hb_list_finding_regressions(finding_id: str) -> str:
+    """List a finding's regression-retest history (newest first).
+
+    Each entry is a past retest: {experiment_id, outcome, partial,
+    testing_level, created_at}. Empty when the finding has never been retested.
+
+    Args:
+        finding_id: Finding UUID.
+    """
+    try:
+        client = _get_client()
+        return _ok(client.list_finding_regressions(finding_id))
+    except HumanboundError as e:
+        return _err(e)
+
+
 # =========================================================================
 # COVERAGE & POSTURE TOOLS
 # =========================================================================

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -406,6 +406,36 @@ class TestConvenienceMethods:
         )
         assert "findings" in call_url
 
+    @patch("humanbound_cli.client.requests.post")
+    def test_retest_finding_shaping(self, mock_post, client):
+        mock_post.return_value = _mock_response(
+            202, {"experiment_id": "exp-reg-1", "status": "running"}
+        )
+        result = client.retest_finding("find-001", testing_level="system")
+        assert result["experiment_id"] == "exp-reg-1"
+        call = mock_post.call_args
+        call_url = call.args[0] if call.args else call.kwargs.get("url", "")
+        # Top-level route (project resolved from the finding server-side).
+        assert call_url.endswith("findings/find-001/retest")
+        assert call.kwargs.get("json") == {"testing_level": "system"}
+        headers = call.kwargs.get("headers", {})
+        assert headers.get("organisation_id") == "org-123"
+        assert "project_id" not in headers
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_list_finding_regressions_shaping(self, mock_get, client):
+        mock_get.return_value = _mock_response(
+            200, [{"experiment_id": "exp-reg-1", "outcome": "not_reproduced"}]
+        )
+        result = client.list_finding_regressions("find-001")
+        assert isinstance(result, list)
+        assert result[0]["outcome"] == "not_reproduced"
+        call = mock_get.call_args
+        call_url = call.args[0] if call.args else call.kwargs.get("url", "")
+        assert call_url.endswith("findings/find-001/regressions")
+        headers = call.kwargs.get("headers", {})
+        assert "project_id" not in headers
+
     @patch("humanbound_cli.client.requests.get")
     def test_list_members(self, mock_get, client):
         mock_get.return_value = _mock_response(200, {"data": [{"email": "a@b.c"}]})

--- a/tests/unit/test_findings.py
+++ b/tests/unit/test_findings.py
@@ -262,3 +262,181 @@ class TestOutputFormat:
         result = runner.invoke(cli, ["findings", "--json"])
         data = assert_valid_json(result)
         assert isinstance(data, dict)
+
+
+# ---------------------------------------------------------------------------
+# Regression retest (retest + regressions)
+# ---------------------------------------------------------------------------
+
+
+RETEST_RESPONSE = {"experiment_id": "exp-reg-1", "status": "running"}
+
+REGRESSIONS_HISTORY = [
+    {
+        "experiment_id": "exp-reg-2",
+        "outcome": "not_reproduced",
+        "partial": False,
+        "testing_level": "unit",
+        "created_at": "2026-07-19T10:00:00Z",
+    },
+    {
+        "experiment_id": "exp-reg-1",
+        "outcome": "still_vulnerable",
+        "partial": True,
+        "testing_level": "system",
+        "created_at": "2026-07-18T09:00:00Z",
+    },
+]
+
+
+class TestRetest:
+    @patch(PATCH)
+    def test_fire_and_return(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001"])
+        assert_exit_ok(result)
+        assert "exp-reg-1" in result.output
+        mock.retest_finding.assert_called_once_with("find-001", testing_level="unit")
+        # Fire-and-return must NOT poll.
+        mock.get_experiment_status.assert_not_called()
+
+    @patch(PATCH)
+    def test_testing_level_passed(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        MockCls.return_value = mock
+        result = runner.invoke(
+            cli, ["findings", "retest", "find-001", "--testing-level", "acceptance"]
+        )
+        assert_exit_ok(result)
+        mock.retest_finding.assert_called_once_with("find-001", testing_level="acceptance")
+
+    @patch(PATCH)
+    def test_deep_shortcut_maps_to_system(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--deep"])
+        assert_exit_ok(result)
+        mock.retest_finding.assert_called_once_with("find-001", testing_level="system")
+
+    @patch(PATCH)
+    def test_full_shortcut_maps_to_acceptance(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--full"])
+        assert_exit_ok(result)
+        mock.retest_finding.assert_called_once_with("find-001", testing_level="acceptance")
+
+    @patch(PATCH)
+    def test_invalid_testing_level_rejected(self, MockCls):
+        mock = _make_client()
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--testing-level", "bogus"])
+        assert result.exit_code != 0
+
+    @patch(PATCH)
+    def test_json_fire_and_return(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--json"])
+        assert_exit_ok(result)
+        data = json.loads(result.output)
+        assert data["experiment_id"] == "exp-reg-1"
+
+    @patch(PATCH)
+    def test_watch_clean_outcome(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        mock.get_experiment_status.return_value = {"status": "Finished"}
+        mock.get_experiment.return_value = {
+            "results": {"regression": {"outcome": "not_reproduced", "partial": False}}
+        }
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--watch"])
+        assert_exit_ok(result)
+        assert "not_reproduced" in result.output
+        mock.get_experiment_status.assert_called()
+
+    @patch(PATCH)
+    def test_watch_still_vulnerable_exits_nonzero(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.return_value = RETEST_RESPONSE
+        mock.get_experiment_status.return_value = {"status": "Finished"}
+        mock.get_experiment.return_value = {
+            "results": {"regression": {"outcome": "still_vulnerable"}}
+        }
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001", "--watch"])
+        assert result.exit_code != 0
+        assert "still_vulnerable" in result.output
+
+    @patch(PATCH)
+    def test_not_authenticated(self, MockCls):
+        mock = _make_client()
+        mock.is_authenticated.return_value = False
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001"])
+        assert result.exit_code != 0
+        assert "Not authenticated" in result.output
+
+    @patch(PATCH)
+    def test_no_project(self, MockCls):
+        mock = _make_client()
+        mock.project_id = None
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001"])
+        assert result.exit_code != 0
+        assert "No project" in result.output
+
+    @patch(PATCH)
+    def test_api_error(self, MockCls):
+        mock = _make_client()
+        mock.retest_finding.side_effect = APIError("Server error", 500)
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "retest", "find-001"])
+        assert result.exit_code != 0
+
+
+class TestRegressions:
+    @patch(PATCH)
+    def test_history_table(self, MockCls):
+        mock = _make_client()
+        mock.list_finding_regressions.return_value = REGRESSIONS_HISTORY
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "regressions", "find-001"])
+        assert_exit_ok(result)
+        assert "not_reproduced" in result.output
+        mock.list_finding_regressions.assert_called_once_with("find-001")
+
+    @patch(PATCH)
+    def test_history_empty(self, MockCls):
+        mock = _make_client()
+        mock.list_finding_regressions.return_value = []
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "regressions", "find-001"])
+        assert_exit_ok(result)
+        assert "never been retested" in result.output
+
+    @patch(PATCH)
+    def test_history_json(self, MockCls):
+        mock = _make_client()
+        mock.list_finding_regressions.return_value = REGRESSIONS_HISTORY
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "regressions", "find-001", "--json"])
+        assert_exit_ok(result)
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+    @patch(PATCH)
+    def test_api_error(self, MockCls):
+        mock = _make_client()
+        mock.list_finding_regressions.side_effect = APIError("Server error", 500)
+        MockCls.return_value = mock
+        result = runner.invoke(cli, ["findings", "regressions", "find-001"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Adds `hb findings retest` and `hb findings regressions`, exposing the backend finding **regression harness** through the CLI and MCP server. A regression retest replays a finding's own recorded attacks against the *current* agent to verify whether it is actually fixed.

## Commands

- **`hb findings retest <id>`** — reports `still_vulnerable` / `not_reproduced` / `insufficient_evidence`.
  - Fire-and-return by default (prints the new experiment id); `--watch` polls to completion and renders the outcome.
  - `--testing-level unit|system|acceptance` sets replay breadth, with `--deep` (=system) / `--full` (=acceptance) shortcuts — same ladder as `hb test`.
- **`hb findings regressions <id>`** — retest history, newest first.

## Under the hood

- Client: `retest_finding` / `list_finding_regressions` on the top-level, org-scoped `findings/{id}/...` routes (the backend resolves the project from the finding).
- MCP: `hb_retest_finding` + `hb_list_finding_regressions` tools.
- Docs: "Verifying a Fix" section on the Findings page, command reference, MCP tool + example query, CHANGELOG.

## Testing

- Unit coverage for both commands (fire-and-return, `--watch` clean + `still_vulnerable` exit codes, `--json`, `--deep`/`--full` shortcuts, auth/project/API-error paths, invalid level) and client request-shaping (path, org-only headers, body).
- Full unit suite green (911 passed); `ruff` clean; `mkdocs build --strict` passes.

## Dependency

Requires the backend regression endpoints (`POST findings/{id}/retest`, `GET findings/{id}/regressions`) — currently on the `be` branch `feat/finding-regression-harness`, not yet merged. This CLI is inert until that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)