### PR TITLE
security: store local secrets 0600 and escape OAuth callback output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Local secret files are written atomically at `0600`** (#67, thanks
+  @JChario). `credentials.json`, the provider `config.yaml`, and the telemetry
+  state file could briefly exist world-readable on first write (created at the
+  process umask before `chmod`); they are now written via an atomic temp-file +
+  `os.replace` helper and are never world-readable. The OAuth login callback
+  error page also escapes the reflected `error_description` to prevent a
+  reflected-XSS in that page.
+
 ## [2.8.0] — 2026-07-30
 
 ### Added

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -4,6 +4,7 @@
 
 import base64
 import hashlib
+import html
 import http.server
 import json
 import os
@@ -26,6 +27,7 @@ from .config import (
     get_auth0_client_id,
     get_auth0_domain,
     get_base_url,
+    write_secure_file,
 )
 from .exceptions import (
     APIError,
@@ -380,7 +382,12 @@ class HumanboundClient:
                     self.send_response(400)
                     self.send_header("Content-type", "text/html")
                     self.end_headers()
-                    error_html = ERROR_HTML.replace("{{ERROR}}", str(auth_result["error"]))
+                    # error_description is an attacker-influenceable query
+                    # parameter on the OAuth redirect; escape it before
+                    # interpolating into the page to prevent reflected XSS.
+                    error_html = ERROR_HTML.replace(
+                        "{{ERROR}}", html.escape(str(auth_result["error"]))
+                    )
                     self.wfile.write(error_html.encode())
 
             def log_message(self, format, *args):
@@ -579,10 +586,11 @@ class HumanboundClient:
         return {}
 
     def _save_credentials(self, refresh_token: str | None = None) -> None:
-        """Save credentials to disk."""
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        TOKEN_FILE.chmod(0o600) if TOKEN_FILE.exists() else None
+        """Save credentials to disk with owner-only (0600) permissions.
 
+        Written atomically so the file never exists on disk in a world-readable
+        state, even on first creation (see ``write_secure_file``).
+        """
         credentials = {
             "api_token": self._api_token,
             "expires_at": self._token_expires_at,
@@ -595,8 +603,7 @@ class HumanboundClient:
             "default_organisation_id": self._default_organisation_id,
         }
 
-        TOKEN_FILE.write_text(json.dumps(credentials))
-        TOKEN_FILE.chmod(0o600)
+        write_secure_file(TOKEN_FILE, json.dumps(credentials))
 
     # -------------------------------------------------------------------------
     # Context Management

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -476,6 +476,13 @@ class HumanboundClient:
         if TOKEN_FILE.exists():
             TOKEN_FILE.unlink()
 
+        # A temp stranded by a crash mid-write can carry a refresh token past logout.
+        for stale in TOKEN_FILE.parent.glob(f".{TOKEN_FILE.name}.*.tmp"):
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+
         if not silent:
             print("Logged out successfully.")
 

--- a/humanbound_cli/commands/config_cmd.py
+++ b/humanbound_cli/commands/config_cmd.py
@@ -12,6 +12,8 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from ..config import write_secure_file
+
 console = Console()
 
 CONFIG_DIR = Path.home() / ".humanbound"
@@ -39,17 +41,18 @@ def _read_config():
 
 
 def _write_config(config):
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # The local provider config holds the plaintext provider API key, so it is
+    # written with owner-only (0600) permissions — matching how credentials.json
+    # and the telemetry state file are stored — instead of inheriting the
+    # process umask (typically 0644 -> group/world readable on shared hosts).
     try:
         import yaml
 
-        CONFIG_FILE.write_text(yaml.dump(config, default_flow_style=False))
+        content = yaml.dump(config, default_flow_style=False)
     except ImportError:
         # Fallback YAML writer
-        lines = []
-        for k, v in config.items():
-            lines.append(f"{k}: {v}")
-        CONFIG_FILE.write_text("\n".join(lines) + "\n")
+        content = "\n".join(f"{k}: {v}" for k, v in config.items()) + "\n"
+    write_secure_file(CONFIG_FILE, content)
 
 
 @click.group("config", invoke_without_command=True)

--- a/humanbound_cli/config.py
+++ b/humanbound_cli/config.py
@@ -3,6 +3,7 @@
 """Humanbound SDK configuration."""
 
 import os
+import tempfile
 from pathlib import Path
 
 # Default API base URL (can be overridden for on-prem deployments)
@@ -24,6 +25,42 @@ LONG_TIMEOUT = 120  # For operations like report generation
 # PostHog telemetry configuration.
 POSTHOG_PUBLIC_KEY = "phc_yKExP2tUyiPGg3kY3tongw36iGLTYaH7D2DfRCHpZg9r"
 POSTHOG_HOST = "https://eu.i.posthog.com"
+
+
+def write_secure_file(path, content: str) -> None:
+    """Atomically write ``content`` to ``path`` with owner-only (0600) permissions.
+
+    The file is created via a temporary file in the same directory and then
+    atomically ``os.replace``-d into place, so it never exists on disk in a
+    partially-written or world-readable state. This closes the brief window in
+    which a naive ``write_text`` followed by ``chmod`` leaves a freshly-created
+    file at the process umask (typically ``0644`` -> group/world readable).
+
+    File modes are advisory no-ops on Windows, where user-profile ACLs apply
+    instead; behaviour there is unchanged.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        try:
+            os.chmod(tmp, 0o600)
+        except (OSError, NotImplementedError):
+            pass
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def get_base_url() -> str:

--- a/humanbound_cli/config.py
+++ b/humanbound_cli/config.py
@@ -46,7 +46,15 @@ def write_secure_file(path, content: str) -> None:
     except (OSError, NotImplementedError):
         pass
 
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    except PermissionError as e:
+        # mkstemp needs write on the parent dir (e.g. a root-owned ~/.humanbound).
+        raise PermissionError(
+            f"Could not write {path} securely: its directory {path.parent} is not "
+            f"writable by the current user (e.g. created by a previous root/`sudo` run). "
+            f"Fix ownership with: sudo chown -R $(id -un) {path.parent}"
+        ) from e
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)

--- a/humanbound_cli/telemetry/consent.py
+++ b/humanbound_cli/telemetry/consent.py
@@ -49,11 +49,8 @@ def _read_state() -> dict:
 
 
 def _write_state(state: dict) -> None:
-    """Persist the state dict atomically-ish with mode 0600."""
-    f = _state_file()
-    f.parent.mkdir(parents=True, exist_ok=True)
-    f.write_text(json.dumps(state) + "\n")
-    f.chmod(0o600)
+    """Persist the state dict atomically with owner-only (0600) permissions."""
+    config.write_secure_file(_state_file(), json.dumps(state) + "\n")
 
 
 def _is_editable_install() -> bool:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -108,6 +108,16 @@ class TestAuthentication:
         assert not token_file.exists()
 
     @patch("humanbound_cli.client.requests.get")
+    def test_logout_sweeps_stranded_temp_files(self, mock_get, client, tmp_path):
+        mock_get.return_value = _mock_response(204)
+        stray = tmp_path / ".humanbound" / ".credentials.json.abc123.tmp"
+        stray.write_text('{"refresh_token": "leak"}')
+
+        client.logout(silent=True)
+
+        assert not stray.exists()
+
+    @patch("humanbound_cli.client.requests.get")
     def test_logout_calls_server_revoke(self, mock_get, client):
         """Logout must notify the server so concurrent sessions
         (platform, other terminals) are also revoked."""

--- a/tests/unit/test_secure_storage.py
+++ b/tests/unit/test_secure_storage.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Tests for owner-only secure file writes (config.write_secure_file).
+
+These cover the credential/provider-key storage hardening: secret files must be
+created atomically with 0600 permissions so they are never world-readable, even
+on first creation.
+"""
+
+import os
+import stat
+
+import pytest
+
+from humanbound_cli.config import write_secure_file
+
+
+def test_write_secure_file_writes_content(tmp_path):
+    target = tmp_path / "nested" / "credentials.json"
+    write_secure_file(target, '{"api_token": "secret"}')
+    assert target.read_text() == '{"api_token": "secret"}'
+
+
+def test_write_secure_file_overwrites_and_leaves_no_temp(tmp_path):
+    target = tmp_path / "config.yaml"
+    write_secure_file(target, "first")
+    write_secure_file(target, "second")
+    assert target.read_text() == "second"
+    # The atomic replace must not leave temp artifacts behind.
+    assert [p.name for p in tmp_path.iterdir()] == ["config.yaml"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
+def test_write_secure_file_is_owner_only(tmp_path):
+    target = tmp_path / "credentials.json"
+    write_secure_file(target, "x")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700

--- a/tests/unit/test_secure_storage.py
+++ b/tests/unit/test_secure_storage.py
@@ -36,3 +36,13 @@ def test_write_secure_file_is_owner_only(tmp_path):
     write_secure_file(target, "x")
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+
+
+def test_write_secure_file_reports_unwritable_dir_clearly(tmp_path, monkeypatch):
+    # Simulate a foreign-owned parent dir (needs root to reproduce for real).
+    def _deny(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("humanbound_cli.config.tempfile.mkstemp", _deny)
+    with pytest.raises(PermissionError, match="not writable by the current user"):
+        write_secure_file(tmp_path / "credentials.json", "x")


### PR DESCRIPTION
## What this does

Hardens how the CLI stores local secrets on disk and how it renders untrusted
input in the OAuth callback page. Three small, related fixes plus a shared helper
and tests. No public API changes; behaviour on Windows is unchanged.

These came out of an independent security review of `humanbound` 2.6.0. Each item
below includes the root-cause analysis so the *why* is reviewable, not just the *what*.

---

### 1. Provider API key was written world-readable (`~/.humanbound/config.yaml`)

**Root cause.** `hb config set api-key <key>` persists the raw provider key through
`_write_config`, which called `CONFIG_FILE.write_text(...)` with no mode restriction:

```python
# before — humanbound_cli/commands/config_cmd.py
CONFIG_FILE.write_text(yaml.dump(config, default_flow_style=False))
```

On POSIX with the usual `umask 022`, the file is created `0644` — readable by every
other local user and by any process in the file's group.

**Why it matters.** This file holds a plaintext, billable provider credential
(OpenAI / Anthropic / Azure). Notably, the project already knows the right pattern
and applies it to its *other* two secret stores — `credentials.json`
(`client._save_credentials`) and the telemetry state file (`consent._write_state`)
both `chmod(0o600)`. So `config.yaml` was an inconsistency, not a deliberate choice.
On a shared/multi-user host (CI runner, dev box, jump host) the key is exposed.

### 2. `credentials.json` was created before `chmod` — first-login TOCTOU window

**Root cause.** `_save_credentials` wrote the file and *then* tightened the mode:

```python
# before — humanbound_cli/client.py
TOKEN_FILE.chmod(0o600) if TOKEN_FILE.exists() else None   # no-op on first run
...
TOKEN_FILE.write_text(json.dumps(credentials))             # created at umask (0644)
TOKEN_FILE.chmod(0o600)                                     # tightened afterwards
```

On the **first** login the file does not pre-exist, so the guarded `chmod` is a
no-op and `write_text` creates it at the process umask. There is then a brief window
in which `api_token` and `refresh_token` sit on disk world-readable before the
trailing `chmod` runs — a classic write-then-chmod race (CWE-367 / CWE-276).

**Fix for 1 & 2.** A single shared helper, `config.write_secure_file()`, writes to a
temp file in the same directory and `os.replace()`s it into place. The destination
therefore *never* exists on disk in a partially-written or world-readable state, even
on first creation. The parent directory is set to `0700`. `chmod` is a documented
no-op on Windows (user-profile ACLs apply); behaviour there is unchanged.

```python
# after — humanbound_cli/config.py
def write_secure_file(path, content: str) -> None:
    ...
    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
    with os.fdopen(fd, "w", encoding="utf-8") as handle:
        handle.write(content)
    os.chmod(tmp, 0o600)
    os.replace(tmp, path)   # atomic; no world-readable window
```

### 3. Reflected input in the OAuth callback error page was not escaped

**Root cause.** During `hb login`, a local HTTP server handles the Auth0 redirect.
The error branch reflected the `error_description` query parameter straight into the
HTML via `str.replace` with no escaping:

```python
# before — humanbound_cli/client.py
error_html = ERROR_HTML.replace("{{ERROR}}", str(auth_result["error"]))
```

`error_description` is an attacker-influenceable value on the redirect URL, and the
callback listens on a local port for the duration of the login flow. Reflecting it
verbatim allows attacker-controlled markup/script to render in that page.

**Fix.** Escape before interpolation — mirroring the escaping the report generator
(`report.py`) already applies consistently:

```python
# after
error_html = ERROR_HTML.replace("{{ERROR}}", html.escape(str(auth_result["error"])))
```

---

## Testing

- Added `tests/unit/test_secure_storage.py` covering the atomic `0600` write, the
  no-temp-file-left-behind guarantee, and (POSIX-only) the resulting file/dir modes.
- **Full suite green on Linux:** `893 passed` (Ubuntu, Python 3.10).
  *(On Windows a handful of pre-existing tests assert POSIX file modes that Windows
  cannot enforce; that set is unchanged by this PR.)*

## Compatibility / scope

- No changes to any public (`humanbound`) or CLI-facing behaviour; the config/token
  file formats and locations are identical.
- Windows behaviour is unchanged (file modes are advisory there).
- Purely local-storage / output-escaping hardening — no protocol or platform-API changes.

## Notes

Part of a broader review; separate PRs follow for MCP-server error handling and
CI/CD hardening. One higher-severity item is being reported privately via
`SECURITY.md` per your coordinated-disclosure policy rather than in a public PR.
