### PR TITLE
ci: pin actions to commit SHAs and scope release permissions per-job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     name: Lint + type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -37,8 +37,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -50,8 +50,8 @@ jobs:
     name: Build wheel + sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip build
@@ -60,7 +60,7 @@ jobs:
         run: |
           pip install twine
           twine check dist/*
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/contract-check.yml
+++ b/.github/workflows/contract-check.yml
@@ -20,8 +20,8 @@ jobs:
     name: Fixtures match mirror schemas
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify every commit carries a Signed-off-by trailer
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const commits = await github.paginate(github.rest.pulls.listCommits, {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
       - name: Install Cairo/Pango (required by mkdocs-material social plugin)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,25 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
+# No workflow-level permissions block: each job requests only what it needs
+# (least privilege). Elevated scopes -- especially id-token: write, which can
+# mint an OIDC token for Trusted Publishing -- are confined to the single job
+# that uses them, so a compromised action/step in another job cannot reach them.
 
 jobs:
   build-main:
     name: Build humanbound
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip build
       - run: python -m build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist-main
           path: dist/
@@ -35,11 +38,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist-main
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           attestations: true
 
@@ -47,9 +50,11 @@ jobs:
     name: Create GitHub Release
     needs: [publish-main]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist-main
           path: dist/
@@ -60,7 +65,7 @@ jobs:
           VERSION="${TAG#v}"
           awk "/^## \[${VERSION}\]/{flag=1;print;next}/^## \[/{flag=0}flag" CHANGELOG.md > release_notes.md
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           body_path: release_notes.md


### PR DESCRIPTION
## What this does

Two CI/CD supply-chain hardening changes, config-only. From an independent security
review of `humanbound` 2.6.0. No change to *what* the workflows do — only how actions
are referenced and how the release token is scoped.

---

### 1. Pin every third-party Action to a full commit SHA (CWE-829)

**Root cause.** All five workflows referenced actions by **mutable** refs — floating
major tags (`@v7`/`@v8`/`@v6`/`@v3`) and, worst case, a **branch** ref
(`pypa/gh-action-pypi-publish@release/v1`). Tags and branches can be force-moved by the
action's maintainer — or by an attacker who compromises that account/repo — and CI
resolves the ref at run time. A retargeted malicious version therefore executes
automatically, with **no change on this side**.

**Why it's highest-impact in `release.yml`.** `download-artifact`, `pypi-publish` and
`gh-release` run in jobs holding `id-token: write` / `contents: write`. A compromised
action there could mint an OIDC token and publish a **trojaned wheel to PyPI** (affecting
every `pip install humanbound` user) or forge release artifacts.

**Fix.** Each `uses:` is pinned to a 40-char commit SHA with the human-readable version in
a trailing comment. Dependabot (already enabled for the `github-actions` ecosystem)
understands this format and will keep proposing bumps — now as reviewable SHA diffs.

| Action | Version | Pinned SHA |
|---|---|---|
| `actions/checkout` | v7 | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
| `actions/setup-python` | v6 | `ece7cb06caefa5fff74198d8649806c4678c61a1` |
| `actions/upload-artifact` | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | v8 | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/github-script` | v7 | `f28e40c7f34bde8b3046d885e986cb6290c5673b` |
| `softprops/action-gh-release` | v3 | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` |
| `pypa/gh-action-pypi-publish` | v1.14.1 | `ba38be9e461d3875417946c167d0b5f3d385a247` |

> **Note on `pypa/gh-action-pypi-publish`:** pypa intentionally ships the moving
> `release/v1` branch so consumers auto-receive security fixes. I've pinned it to the
> current release SHA (v1.14.1) for a consistent, auditable posture, but if you prefer
> pypa's auto-update model, reverting *just that one line* to `@release/v1` is reasonable
> — your call.

### 2. Least-privilege permissions in `release.yml` (CWE-250)

**Root cause.** `release.yml` set `permissions: contents: write` + `id-token: write` at the
**workflow level**, so every job inherited both. But:

- `build-main` runs `python -m build` (executing the build backend + third-party build
  tooling) and needs neither OIDC-minting nor repo-write — yet inherited both.
- `publish-main` already re-declares `id-token: write` at job level (which *replaces* the
  inherited set), so it was correctly scoped; the top-level grant existed only to serve the
  other jobs, which don't need it.
- `release` needs `contents: write` (to create the GitHub release) and nothing else.

**Fix.** Remove the top-level block; each job requests only what it needs:
`build-main → contents: read`, `publish-main → id-token: write`, `release → contents: write`.
This confines the OIDC-minting capability to the single job that performs Trusted Publishing.

## What's *not* in this PR

- **Pinning `mkdocs-material[imaging]` in `docs.yml`** (a lower-priority unpinned-install
  in a `contents: write` job) is left out deliberately: I don't know your tested version,
  and pinning to the wrong one would break the docs build. Recommend pinning it to your
  known-good version (or a bounded range) in a follow-up.

## Testing / notes

- All five workflow files re-parse as valid YAML; no floating refs remain and every pinned
  ref keeps its version comment.
- Config-only change — no Python touched, so the `Lint`, `Test`, `Build` and
  `Contract fidelity` checks are unaffected.
- Each SHA above can be independently verified, e.g.
  `gh api repos/actions/checkout/commits/v7 -q .sha`.
