### PR TITLE
fix(cli): tolerate optional bot-config keys and stop reporting all-errored runs as passing  Fixes #51. Supersedes #57 and #60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GitHub Action (local-mode Quickstart, SARIF/Security-tab guidance) plus a
   working GitLab/CLI example, replacing the prior platform-mode-only examples
   that could not run.
+- **`hb test` exit codes are now an explicit contract**, documented in
+  `hb test --help`: `0` scan completed with no `--fail-on` match, `1` scan
+  completed and the `--fail-on` condition matched, `2` the scan itself failed
+  (run status `Failed`, or no conversation completed). Previously a `Failed`
+  run exited `1` with no message; it now exits `2` with a reason line, and a
+  scan failure takes precedence over `--fail-on`.
 
 ### Fixed
+- **Bot configs without `chat_completion.headers`/`payload` no longer crash
+  every conversation** (#51). Both keys are optional and default to `{}` across
+  all three transports (non-streaming, WebSocket, SSE); an omitted payload uses
+  the documented OpenAI-style `messages` fallback. A missing
+  `chat_completion.endpoint` now fails with a clear config error instead of a
+  raw `KeyError`.
+- **A run where every conversation errored is no longer reported as passing**
+  (#51). Instead of a green `Finished / Pass: 0 / Fail: 0` panel and exit `0`,
+  `hb test` now shows an `Errored: N` count with an explicit "NOT a passing
+  result" warning and exits `2` — an all-error run reading as "safe" was the
+  dangerous failure mode for a security scanner.
 - Telemetry is now auto-disabled on **editable / source-checkout installs**
   (`pip install -e .`); previously only `HUMANBOUND_DEV=1` disabled development
   runs.

--- a/docs/docs/integrations/cicd.md
+++ b/docs/docs/integrations/cicd.md
@@ -16,6 +16,8 @@ faq:
     a: "Yes. The official [`humanbound/actions`](https://github.com/marketplace/actions/humanbound-ai-agent-security-testing) Action wraps `hb test` — it installs the CLI, runs the scan, gates the build with `fail-on`, and uploads findings to the GitHub Security tab as SARIF. Reference it as `uses: humanbound/actions@v1`."
   - q: What does the --fail-on flag do in CI/CD?
     a: The `--fail-on` flag causes the `hb test` command to exit with a non-zero status code when vulnerabilities at or above the specified severity are found. Thresholds are `critical`, `high`, `medium`, `low`, and `any`, allowing you to configure how strict your security gate is.
+  - q: What exit codes does hb test return?
+    a: "`0` — the scan completed and no `--fail-on` condition matched. `1` — the scan completed and the `--fail-on` condition matched. `2` — the scan itself failed: the run ended with status `Failed`, or every conversation errored so nothing was actually tested. A scan failure exits `2` regardless of `--fail-on`, so a broken scan can never pass your gate."
   - q: What does --wait do and why should I use it in CI/CD?
     a: "`--wait` tells Humanbound to block until the test run completes before the command exits. Always use `--wait` in CI/CD pipelines to ensure results are available before the job finishes or artifacts are exported. (The GitHub Action passes `--wait` for you.)"
 ---
@@ -32,7 +34,7 @@ Action; on **GitLab** and other systems, run the `hb` CLI directly.
 1. **Your pipeline boots the agent** (or points at a running one) and hands its endpoint to Humanbound.
 2. **Humanbound attacks it** — multi-turn adversarial conversations (OWASP-aligned prompt injection, tool misuse, data exfiltration, and more).
 3. **An LLM judge scores every response** and records findings with severities.
-4. **The result gates your build** — `fail-on` sets the exit code; on GitHub, findings also land in the Security tab as SARIF, with a severity summary on the run page.
+4. **The result gates your build** — exit `0` on a clean pass, `1` when `fail-on` matches, and `2` when the scan itself failed (run `Failed`, or every conversation errored — a broken scan can never read as green). On GitHub, findings also land in the Security tab as SARIF, with a severity summary on the run page.
 
 ## GitHub Actions
 

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -20,6 +20,13 @@ from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
 
+# Process exit codes — part of the CI contract, documented in `hb test --help`.
+# The 1 vs 2 split follows the grep/pytest convention: "the scan ran and found
+# something" is a different condition than "the scan itself could not run".
+EXIT_OK = 0  # scan completed; no --fail-on condition met
+EXIT_FINDINGS = 1  # scan completed; --fail-on condition matched
+EXIT_RUN_FAILED = 2  # scan failed: run status Failed, or no conversation completed
+
 # Default test category
 DEFAULT_TEST_CATEGORY = "humanbound/adversarial/owasp_agentic"
 
@@ -346,6 +353,12 @@ def test_command(
       hb test --deep                              # System-level test (~45 min)
       hb test --full                              # Acceptance-level test (~90 min)
       hb test --category humanbound/behavioral/qa # Behavioral/QA tests
+
+    \b
+    Exit codes:
+      0  scan completed; no --fail-on condition met
+      1  scan completed; the --fail-on condition matched
+      2  scan failed: run status Failed, or no conversation completed
     """
     # Resolve shorthand flags — explicit --testing-level / --test-category win
     if category and test_category == DEFAULT_TEST_CATEGORY:
@@ -576,7 +589,8 @@ def test_command(
             _findings_seen = 0
 
         # Display results (same rendering, canonical shapes)
-        _display_results(result, posture)
+        all_errored = _all_errored(result.stats)
+        _display_results(result, posture, all_errored)
 
         # Next suggestions — vary by mode
         if is_platform:
@@ -598,17 +612,12 @@ def test_command(
                 ]
             )
 
-        # Check fail-on condition
-        if fail_on:
-            exit_code = _check_fail_on(result, fail_on)
-            if exit_code != 0:
-                console.print(f"\n[red]Failing due to --fail-on={fail_on} condition[/red]")
-                raise SystemExit(exit_code)
-
-        if final_status == "Failed":
-            raise SystemExit(1)
-
-        outcome = "completed"
+        exit_code, exit_reason = _resolve_exit(result, final_status, fail_on)
+        # A --fail-on exit is still a completed scan; a run failure is not.
+        outcome = "error" if exit_code == EXIT_RUN_FAILED else "completed"
+        if exit_code != EXIT_OK:
+            console.print(f"\n[red]{exit_reason}[/red]")
+            raise SystemExit(exit_code)
 
     except NotAuthenticatedError:
         telemetry.fire_gated_command_hit()
@@ -827,11 +836,44 @@ def _wait_verbose(runner, experiment_id: str) -> str:
     return status.status
 
 
-def _display_results(result: TestResult, posture: Posture):
-    """Display experiment results with posture grade and findings summary.
+def _all_errored(stats: dict) -> bool:
+    """True when the run produced conversations but none completed — i.e. every
+    conversation errored (0 pass, 0 fail, >0 error).
 
-    Uses canonical TestResult and Posture shapes — works identically
-    for both platform and local runners.
+    Such a run carries no security signal at all and must not be presented as a
+    pass: "Pass: 0 / Fail: 0" on a fully-errored run reads as "my agent is clean"
+    when in fact nothing was actually tested.
+    """
+    total = stats.get("total", 0) or 0
+    completed = (stats.get("pass", 0) or 0) + (stats.get("fail", 0) or 0)
+    errored = stats.get("error", 0) or 0
+    return total > 0 and completed == 0 and errored > 0
+
+
+def _resolve_exit(result: TestResult, final_status: str, fail_on: str) -> tuple[int, str | None]:
+    """Single source of truth for hb test's exit code (see `Exit codes` in --help).
+
+    Checked in severity order: a run that failed outright — or where every
+    conversation errored, i.e. nothing was actually tested — is a scan failure
+    (EXIT_RUN_FAILED) regardless of --fail-on, which only inspects insight
+    severity and sees nothing in either case.
+    """
+    if final_status == "Failed":
+        return EXIT_RUN_FAILED, "Run failed — no results produced."
+    if _all_errored(result.stats):
+        return EXIT_RUN_FAILED, "No conversations completed — treating this run as a failure."
+    if fail_on and _check_fail_on(result, fail_on) != 0:
+        return EXIT_FINDINGS, f"Failing due to --fail-on={fail_on} condition"
+    return EXIT_OK, None
+
+
+def _build_results_panel(
+    result: TestResult, posture: Posture, all_errored: bool
+) -> tuple[str, list[str], str]:
+    """Build the results panel as data: (title, lines, border_style).
+
+    Pure — no console access — so tests can assert on structure instead of
+    scraping rendered output.
     """
     status = result.status
     status_color = {
@@ -841,8 +883,13 @@ def _display_results(result: TestResult, posture: Posture):
     }.get(status, "white")
 
     stats = result.stats
+    errored = stats.get("error", 0) or 0
 
-    # Build results panel content
+    # A run where every conversation errored produced no security signal — don't
+    # paint it green, and don't let "Pass: 0 / Fail: 0" read as a clean pass.
+    if all_errored:
+        status_color = "red"
+
     panel_lines = [
         f"[bold]Status:[/bold] [{status_color}]{status}[/{status_color}]\n",
         "[bold]Results:[/bold]",
@@ -850,6 +897,17 @@ def _display_results(result: TestResult, posture: Posture):
         f"  [green]Pass:[/green] {stats.get('pass', 0)}",
         f"  [red]Fail:[/red] {stats.get('fail', 0)}",
     ]
+    if errored:
+        panel_lines.append(f"  [yellow]Errored:[/yellow] {errored}")
+
+    if all_errored:
+        panel_lines.append("")
+        panel_lines.append("[red bold]⚠ No conversations completed — every one errored.[/red bold]")
+        panel_lines.append(
+            "[red]This is NOT a passing result. Check the agent endpoint/config and "
+            "connectivity, then re-run.[/red]"
+        )
+        panel_lines.append("[dim]Inspect the failures with: hb logs[/dim]")
 
     # Posture grade (available from both runners)
     if posture.grade is not None:
@@ -879,9 +937,19 @@ def _display_results(result: TestResult, posture: Posture):
         )
         panel_lines.append(f"[dim]Previously: {posture.previous_grade}{prev_score_str}[/dim]")
 
-    console.print(
-        Panel("\n".join(panel_lines), title="Experiment Complete", border_style=status_color)
-    )
+    panel_title = "Experiment Complete — no results" if all_errored else "Experiment Complete"
+    return panel_title, panel_lines, status_color
+
+
+def _display_results(result: TestResult, posture: Posture, all_errored: bool) -> None:
+    """Display experiment results with posture grade and findings summary.
+
+    Uses canonical TestResult and Posture shapes — works identically
+    for both platform and local runners. Rendering only: the caller computes
+    `all_errored` (and the exit code) via `_all_errored` / `_resolve_exit`.
+    """
+    title, lines, border_style = _build_results_panel(result, posture, all_errored)
+    console.print(Panel("\n".join(lines), title=title, border_style=border_style))
 
     # Show insights if available
     insights = result.insights

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -377,17 +377,34 @@ class Bot(ResponseExtractor):
         except:
             return resp.text, time.time() - t_start, endpoint
 
+    # resolve the chat_completion request config - single source of truth for all
+    # three transports (__chat / __stream / __stream_sse):
+    #   - `endpoint` is required and validated here with a clear message
+    #   - `headers` / `payload` are optional and default to {} (#51)
+    #   - headers/payload are deep-copied so per-request placeholder substitution
+    #     never mutates the shared bot config
+    def __chat_completion_request(self):
+        cfg = self.bot_config.get("chat_completion") or {}
+        if not cfg.get("endpoint"):
+            raise Exception("400/'chat_completion.endpoint' is required in the bot config.")
+        return (
+            cfg["endpoint"],
+            copy.deepcopy(cfg.get("headers", {})),
+            copy.deepcopy(cfg.get("payload", {})),
+        )
+
     #
     # Handle chat completion requests (streaming and non-streaming)
     #
     def __chat(self, base_payload, u_prompt, conversation):
         try:
             # a. ping
+            endpoint, headers, payload = self.__chat_completion_request()
             messages, exec_t, _ = self.__make_api_call(
                 base_payload,
-                self.bot_config["chat_completion"]["endpoint"],
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
+                endpoint,
+                headers,
+                payload,
                 u_prompt,
                 conversation,
             )
@@ -452,19 +469,10 @@ class Bot(ResponseExtractor):
 
     async def __stream(self, base_payload, u_prompt, conversation=None):
         try:
-            endpoint = self.__prepare_endpoint(
-                self.bot_config["chat_completion"]["endpoint"], base_payload
-            )
-            headers = self.__prepare_headers(
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
-                base_payload,
-            )
-            payload = self.__prepare_payload(
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
-                base_payload,
-                u_prompt,
-                conversation,
-            )
+            endpoint, headers, payload = self.__chat_completion_request()
+            endpoint = self.__prepare_endpoint(endpoint, base_payload)
+            headers = self.__prepare_headers(headers, base_payload)
+            payload = self.__prepare_payload(payload, base_payload, u_prompt, conversation)
 
             try:
                 from websockets.asyncio.client import connect
@@ -514,20 +522,11 @@ class Bot(ResponseExtractor):
     # SSE streaming. Same chunk contract as WS; per-turn telemetry not supported.
     async def __stream_sse(self, base_payload, u_prompt, conversation=None):
         try:
-            endpoint = self.__prepare_endpoint(
-                self.bot_config["chat_completion"]["endpoint"], base_payload
-            )
-            headers = self.__prepare_headers(
-                copy.deepcopy(self.bot_config["chat_completion"]["headers"]),
-                base_payload,
-            )
+            endpoint, headers, payload = self.__chat_completion_request()
+            endpoint = self.__prepare_endpoint(endpoint, base_payload)
+            headers = self.__prepare_headers(headers, base_payload)
             headers.setdefault("user-agent", SSE_DEFAULT_USER_AGENT)
-            payload = self.__prepare_payload(
-                copy.deepcopy(self.bot_config["chat_completion"]["payload"]),
-                base_payload,
-                u_prompt,
-                conversation,
-            )
+            payload = self.__prepare_payload(payload, base_payload, u_prompt, conversation)
 
             buffer, t_start = "", time.time()
             async with httpx.AsyncClient(

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -419,6 +419,37 @@ def test_ping_non_streaming_with_string_response(bot):
     assert resp == "plain text response"
 
 
+def test_ping_non_streaming_without_headers_or_payload():
+    # A chat_completion block with only an endpoint (no `headers`/`payload`) is a
+    # natural shape for a no-auth agent. It must not crash with KeyError; the
+    # engine should default both to {}. Regression test for #51.
+    bot = Bot({"chat_completion": {"endpoint": "https://agent.example/chat"}}, "exp-abc")
+    with patch("humanbound_cli.engine.bot.requests.post") as post:
+        post.return_value = _mock_post(payload={"content": "agent says hi"})
+        resp, _, *_ = asyncio.run(bot.ping({}, "user prompt"))
+        sent = post.call_args.kwargs["json"]
+    assert resp == "agent says hi"
+    # With no `$PROMPT` placeholder and an empty payload, the engine falls back to
+    # the OpenAI-style messages array.
+    assert sent["messages"][-1] == {"role": "user", "content": "user prompt"}
+
+
+@pytest.mark.parametrize(
+    "bot_config",
+    [
+        {},  # no chat_completion block at all
+        {"chat_completion": {}},  # block present, endpoint missing
+        {"chat_completion": {"endpoint": ""}},  # endpoint empty
+    ],
+)
+def test_ping_fails_clearly_when_endpoint_is_missing(bot_config):
+    # Unlike headers/payload, `endpoint` is genuinely required — a missing one
+    # must surface as a clear config error, not a raw KeyError.
+    bot = Bot(bot_config, "exp-abc")
+    with pytest.raises(Exception, match="chat_completion.endpoint"):
+        asyncio.run(bot.ping({}, "user prompt"))
+
+
 # ────────────────────────────────────────────────────────────────
 # Telemetry — smoke coverage
 # ────────────────────────────────────────────────────────────────

--- a/tests/unit/test_errored_run_reporting.py
+++ b/tests/unit/test_errored_run_reporting.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""A run where every conversation errored carries no security signal and must
+not be reported as a pass. Covers `_all_errored`, `_resolve_exit` (the single
+source of truth for hb test's exit code), and the results-panel rendering."""
+
+import io
+
+import pytest
+from rich.console import Console
+
+import humanbound_cli.commands.test as test_cmd
+from humanbound_cli.commands.test import (
+    EXIT_FINDINGS,
+    EXIT_OK,
+    EXIT_RUN_FAILED,
+    _all_errored,
+    _build_results_panel,
+    _display_results,
+    _resolve_exit,
+)
+from humanbound_cli.engine.runner import Posture
+from humanbound_cli.engine.runner import TestResult as _TestResult
+
+
+def _result(stats, insights=None, status="Finished"):
+    return _TestResult(
+        experiment_id="exp-1",
+        name="t",
+        status=status,
+        stats=stats,
+        insights=insights or [],
+    )
+
+
+# ────────────────────────────────────────────────────────────────
+# _all_errored — verdict predicate
+# ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stats,expected",
+    [
+        ({"total": 3, "pass": 0, "fail": 0, "error": 3}, True),  # everything errored
+        ({"total": 5, "pass": 2, "fail": 0, "error": 3}, False),  # some completed
+        ({"total": 5, "pass": 0, "fail": 1, "error": 4}, False),  # a fail counts as signal
+        ({"total": 0, "pass": 0, "fail": 0, "error": 0}, False),  # empty run, different case
+        ({"total": 3, "pass": 3, "fail": 0, "error": 0}, False),  # clean pass
+        ({"total": 3, "pass": 0, "fail": 0}, False),  # no error key at all
+    ],
+)
+def test_all_errored_truth_table(stats, expected):
+    assert _all_errored(stats) is expected
+
+
+# ────────────────────────────────────────────────────────────────
+# _resolve_exit — exit-code policy
+# ────────────────────────────────────────────────────────────────
+
+_CLEAN = {"total": 3, "pass": 3, "fail": 0, "error": 0}
+_ALL_ERRORED = {"total": 3, "pass": 0, "fail": 0, "error": 3}
+_HIGH_INSIGHT = [{"result": "fail", "severity": "high", "explanation": "x"}]
+
+
+@pytest.mark.parametrize(
+    "stats,insights,final_status,fail_on,expected",
+    [
+        (_CLEAN, None, "Finished", "", EXIT_OK),
+        (_CLEAN, _HIGH_INSIGHT, "Finished", "", EXIT_OK),  # findings but no --fail-on
+        (_CLEAN, _HIGH_INSIGHT, "Finished", "high", EXIT_FINDINGS),
+        (_CLEAN, _HIGH_INSIGHT, "Finished", "any", EXIT_FINDINGS),
+        (_CLEAN, _HIGH_INSIGHT, "Finished", "critical", EXIT_OK),  # below threshold
+        (_ALL_ERRORED, None, "Finished", "", EXIT_RUN_FAILED),
+        (_ALL_ERRORED, None, "Finished", "any", EXIT_RUN_FAILED),  # run failure wins
+        (_CLEAN, _HIGH_INSIGHT, "Failed", "high", EXIT_RUN_FAILED),  # Failed wins over fail-on
+        ({"total": 5, "pass": 2, "fail": 0, "error": 3}, None, "Finished", "", EXIT_OK),  # partial
+    ],
+)
+def test_resolve_exit_policy(stats, insights, final_status, fail_on, expected):
+    code, reason = _resolve_exit(_result(stats, insights), final_status, fail_on)
+    assert code == expected
+    assert (reason is None) is (code == EXIT_OK)
+
+
+# ────────────────────────────────────────────────────────────────
+# _build_results_panel — structure, no console needed
+# ────────────────────────────────────────────────────────────────
+
+
+def test_panel_warns_and_goes_red_when_all_errored():
+    title, lines, border = _build_results_panel(_result(_ALL_ERRORED), Posture(), all_errored=True)
+    body = "\n".join(lines)
+    assert title == "Experiment Complete — no results"
+    assert border == "red"
+    assert "Errored:[/yellow] 3" in body
+    assert "No conversations completed" in body
+    assert "NOT a passing result" in body
+
+
+def test_panel_shows_errored_line_without_warning_on_partial_errors():
+    stats = {"total": 5, "pass": 2, "fail": 0, "error": 3}
+    title, lines, border = _build_results_panel(_result(stats), Posture(), all_errored=False)
+    body = "\n".join(lines)
+    assert title == "Experiment Complete"
+    assert border == "green"
+    assert "Errored:[/yellow] 3" in body
+    assert "No conversations completed" not in body
+
+
+def test_panel_is_clean_on_a_normal_pass():
+    title, lines, border = _build_results_panel(
+        _result(_CLEAN), Posture(overall_score=100.0, grade="A"), all_errored=False
+    )
+    body = "\n".join(lines)
+    assert title == "Experiment Complete"
+    assert border == "green"
+    assert "Errored" not in body
+    assert "Posture Grade" in body
+
+
+# ────────────────────────────────────────────────────────────────
+# _display_results — rendering smoke test
+# ────────────────────────────────────────────────────────────────
+
+
+def test_display_renders_the_all_errored_panel(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(test_cmd, "console", Console(file=buf, force_terminal=False, width=100))
+    _display_results(_result(_ALL_ERRORED), Posture(), all_errored=True)
+    out = buf.getvalue()
+    assert "No conversations completed" in out
+    assert "NOT a passing result" in out

--- a/tests/unit/test_insights_wording.py
+++ b/tests/unit/test_insights_wording.py
@@ -37,21 +37,25 @@ def _result():
 class TestTerminalWording:
     def test_insights_section_says_insights_not_findings(self):
         with console.capture() as cap:
-            _display_results(_result(), Posture(grade="F", overall_score=40.0))
+            _display_results(_result(), Posture(grade="F", overall_score=40.0), all_errored=False)
         out = cap.get()
         assert "Top Insights (1 total)" in out
         assert "Top Findings" not in out
 
     def test_insights_section_explains_not_tracked_across_runs(self):
         with console.capture() as cap:
-            _display_results(_result(), Posture(grade="F", overall_score=40.0))
+            _display_results(_result(), Posture(grade="F", overall_score=40.0), all_errored=False)
         out = cap.get()
         assert "not tracked across runs" in out
         assert "hb findings" in out
 
     def test_open_findings_labeled_as_project_level(self):
         with console.capture() as cap:
-            _display_results(_result(), Posture(grade="F", overall_score=40.0, finding_count=2))
+            _display_results(
+                _result(),
+                Posture(grade="F", overall_score=40.0, finding_count=2),
+                all_errored=False,
+            )
         out = cap.get()
         assert "Open Findings (project): 2" in out
 
@@ -64,7 +68,7 @@ class TestTerminalWording:
         )
         result.insights[0]["explanation"] = long_explanation
         with console.capture() as cap:
-            _display_results(result, Posture(grade="F", overall_score=40.0))
+            _display_results(result, Posture(grade="F", overall_score=40.0), all_errored=False)
         out = " ".join(cap.get().split())
         assert long_explanation in out
 
@@ -72,7 +76,7 @@ class TestTerminalWording:
         result = _result()
         result.insights = []
         with console.capture() as cap:
-            _display_results(result, Posture(grade="A", overall_score=95.0))
+            _display_results(result, Posture(grade="A", overall_score=95.0), all_errored=False)
         out = cap.get()
         assert "Top Insights" not in out
         assert "not tracked across runs" not in out

--- a/tests/unit/test_severity_normalization.py
+++ b/tests/unit/test_severity_normalization.py
@@ -34,7 +34,7 @@ class TestDisplayNumericSeverity:
     def test_numeric_severity_renders_label_not_unknown(self):
         result = _result([_insight(80.0)])
         with console.capture() as cap:
-            _display_results(result, Posture(grade="F", overall_score=40.0))
+            _display_results(result, Posture(grade="F", overall_score=40.0), all_errored=False)
         out = cap.get()
         assert "CRITICAL" in out
         assert "UNKNOWN" not in out
@@ -42,7 +42,7 @@ class TestDisplayNumericSeverity:
     def test_string_severity_still_renders(self):
         result = _result([_insight("high")])
         with console.capture() as cap:
-            _display_results(result, Posture(grade="C", overall_score=70.0))
+            _display_results(result, Posture(grade="C", overall_score=70.0), all_errored=False)
         out = cap.get()
         assert "HIGH" in out
         assert "UNKNOWN" not in out
@@ -52,7 +52,7 @@ class TestDisplayNumericSeverity:
         del insight["severity"]
         result = _result([insight])
         with console.capture() as cap:
-            _display_results(result, Posture(grade="C", overall_score=70.0))
+            _display_results(result, Posture(grade="C", overall_score=70.0), all_errored=False)
         assert "UNKNOWN" in cap.get()
 
 


### PR DESCRIPTION
## Summary

A `bot-config.json` whose `chat_completion` block omits `headers` or `payload` — a natural shape for a no-auth agent — crashed every conversation with `KeyError: 'headers'`, and the resulting all-errored run was then reported as a green `Finished / Pass: 0 / Fail: 0` with exit 0: the dangerous failure mode for a security scanner.

Supersedes #57 and #60 — code originated in @jeremyinfomy's closed PRs (blocked by the since-removed CLA), reimplemented and extended per their invitation, with co-authorship credit.

**Engine** — `chat_completion.headers`/`payload` are optional (default `{}`) in all three transports (non-streaming, WebSocket, SSE) via a single `__chat_completion_request()` accessor. An omitted payload uses the documented OpenAI-style `messages` fallback, so the attack prompt is always delivered. A missing `endpoint` now gets a clear `400` config error instead of a raw `KeyError`.

**CLI** — an all-errored run renders a red "no results" panel with an `Errored: N` count and an explicit "NOT a passing result" warning, and exits non-zero. Exit codes are now a documented contract (`hb test --help` and the CI/CD docs page): `0` clean, `1` `--fail-on` matched, `2` scan failed.

**Behavior changes (CI-visible):** `Failed` runs exit `2` (previously `1`, silently); a scan failure outranks `--fail-on`; telemetry `outcome` for a `--fail-on` exit is `completed` (previously `error`).

**Verification:** full suite 939 passed (`[dev,engine]` extras); `ruff check` / `ruff format --check` clean. End-to-end vs a mock agent: a headers-less config runs 97/97 conversations clean (on `main` the identical config errors all 97); a dead endpoint produces the warning panel and exit 2; the `Failed` path exits 2 with a reason line. Streaming transports and platform mode carry the identical mechanical change but were verified at unit level only (live runs used the non-streaming local path).

## Type of change

- [x] Bug fix (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #51. Supersedes #57, #60.