### PR TITLE
docs: align all Discord links to the live invite (fixes #55)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/humanbound/humanbound/discussions
     about: Use Discussions for questions, ideas, and show-and-tell.
   - name: Discord community
-    url: https://discord.gg/gQyXjVBF
+    url: https://discord.gg/WgTMpmSFtN
     about: Chat with the community and the maintainers.
   - name: Documentation
     url: https://docs.humanbound.ai/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that could not run.
 
 ### Fixed
+- **Dead Discord invite replaced** (#55). `CONTRIBUTING.md`, the community and
+  plugins docs pages, and the new-issue chooser linked `discord.gg/gQyXjVBF`,
+  which no longer resolves; all references now use the live permanent invite
+  `discord.gg/WgTMpmSFtN`, matching README and the PyPI project link.
 - Telemetry is now auto-disabled on **editable / source-checkout installs**
   (`pip install -e .`); previously only `HUMANBOUND_DEV=1` disabled development
   runs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ for the current cadence and supported-version matrix.
 
 ## Community
 
-- **Discord** — [discord.gg/gQyXjVBF](https://discord.gg/gQyXjVBF) for questions
+- **Discord** — [discord.gg/WgTMpmSFtN](https://discord.gg/WgTMpmSFtN) for questions
   and discussion
 - **Discussions** — on the GitHub repo, for longer-form topics
 - **Docs** — [docs.humanbound.ai](https://docs.humanbound.ai)

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -22,7 +22,7 @@ Four channels for help, feedback, and updates: the Humanbound Discord server for
 
     Join the community server for support, feature discussions, and early access announcements.
 
-    [:octicons-link-external-16: Join Discord](https://discord.gg/gQyXjVBF)
+    [:octicons-link-external-16: Join Discord](https://discord.gg/WgTMpmSFtN)
 
 - :computer: **GitHub**
 

--- a/docs/docs/plugins/index.md
+++ b/docs/docs/plugins/index.md
@@ -98,4 +98,4 @@ depend on a particular shape.
 
 - **Repository:** [github.com/humanbound/plugins](https://github.com/humanbound/plugins)
 - **Roadmap:** [github.com/humanbound/plugins/blob/main/ROADMAP.md](https://github.com/humanbound/plugins/blob/main/ROADMAP.md)
-- **Discord:** [discord.gg/gQyXjVBF](https://discord.gg/gQyXjVBF)
+- **Discord:** [discord.gg/WgTMpmSFtN](https://discord.gg/WgTMpmSFtN)


### PR DESCRIPTION
## Summary

Four repo references linked `discord.gg/gQyXjVBF`, which is a dead invite (Discord's invite API returns `Unknown Invite`) — anyone clicking them from `CONTRIBUTING.md`, the [community](https://docs.humanbound.ai/community/) or [plugins](https://docs.humanbound.ai/plugins/) docs pages, or the new-issue chooser landed on an invalid-invite screen.

All seven repo references now use `discord.gg/WgTMpmSFtN` — the live, permanent invite for the Humanbound server (verified via the Discord invite API), already used by README and the PyPI project link in `pyproject.toml`.

Changed: `CONTRIBUTING.md`, `docs/docs/community.md`, `docs/docs/plugins/index.md`, `.github/ISSUE_TEMPLATE/config.yml`, plus a `CHANGELOG.md` entry. Docs-hooks tests pass (79/79).

Credit to @jeremyinfomy for reporting #55 and mapping all seven occurrences.

## Type of change

- [x] Documentation only

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #55