### PR TITLE
test: skip docs-hook tests when mkdocs is not installed (fixes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugins docs pages, and the new-issue chooser linked `discord.gg/gQyXjVBF`,
   which no longer resolves; all references now use the live permanent invite
   `discord.gg/WgTMpmSFtN`, matching README and the PyPI project link.
+- **`pytest` no longer aborts at collection on a plain install** (#54). The
+  three docs-hook test modules import `mkdocs`, which only ships in the `[dev]`
+  extra; after `pip install -e .` the whole suite died with 3 collection errors
+  before a single test ran. They now `pytest.importorskip("mkdocs")` — a plain
+  install reports them as skipped, and they run normally under `[dev]`/CI.
 - Telemetry is now auto-disabled on **editable / source-checkout installs**
   (`pip install -e .`); previously only `HUMANBOUND_DEV=1` disabled development
   runs.

--- a/tests/unit/test_docs_hooks_lint.py
+++ b/tests/unit/test_docs_hooks_lint.py
@@ -3,8 +3,11 @@
 import logging
 from types import SimpleNamespace
 
-import lint
 import pytest
+
+pytest.importorskip("mkdocs")
+
+import lint
 from mkdocs.exceptions import PluginError
 
 

--- a/tests/unit/test_docs_hooks_llms_txt.py
+++ b/tests/unit/test_docs_hooks_llms_txt.py
@@ -2,6 +2,10 @@
 
 from types import SimpleNamespace
 
+import pytest
+
+pytest.importorskip("mkdocs")
+
 import llms_txt
 
 

--- a/tests/unit/test_docs_hooks_schema.py
+++ b/tests/unit/test_docs_hooks_schema.py
@@ -3,6 +3,9 @@
 from types import SimpleNamespace
 
 import pytest
+
+pytest.importorskip("mkdocs")
+
 import schema  # docs/hooks/schema.py via conftest sys.path injection
 
 


### PR DESCRIPTION
## Summary

After a plain `pip install -e .`, `pytest` aborts at collection — the three docs-hook test modules import `mkdocs`, which only ships in the `[dev]` extra, so the entire suite (860 tests) dies before a single test runs. Reproduced on current `main` in a clean core-only venv.

The three modules now guard with `pytest.importorskip("mkdocs")`: a plain install reports `860 passed, 3 skipped`; under `[dev]`/CI they run normally (79 tests, full suite `939 passed`). `importorskip` was chosen over a conftest `collect_ignore` so the skipped tests stay visible in the report instead of silently disappearing. No CI impact — CI installs `[dev,engine]`.

Supersedes #58 — same approach as @jeremyinfomy's closed PR (blocked by the since-removed CLA), reimplemented with co-author credit, plus a CHANGELOG entry.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #54. Supersedes #58.