### PR TITLE
feat(engine): accept anthropic (and case variants) as provider names …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scan failure takes precedence over `--fail-on`.
 
 ### Fixed
+- **`HB_PROVIDER=anthropic` is now accepted** (#53). The engine only recognized
+  the internal name `claude`, while the README advertises the "Anthropic"
+  provider and the SDK package is `anthropic`. Provider names are now
+  normalized (trimmed, lowercased) and `anthropic` maps to `claude`; the
+  "Unsupported LLM provider" error also lists the available aliases.
 - **Bot configs without `chat_completion.headers`/`payload` no longer crash
   every conversation** (#51). Both keys are optional and default to `{}` across
   all three transports (non-streaming, WebSocket, SSE); an omitted payload uses

--- a/docs/docs/local-engine/provider-config.md
+++ b/docs/docs/local-engine/provider-config.md
@@ -58,7 +58,7 @@ Config is stored at `~/.humanbound/config.yaml`. Never sent to Humanbound.
 | Provider | `HB_PROVIDER` | Key prefix | Notes |
 |---|---|---|---|
 | OpenAI | `openai` | `sk-` | GPT-4o, GPT-4.1, etc. |
-| Anthropic | `claude` | `sk-ant-` | Claude 3.5, Claude 4, etc. |
+| Anthropic | `anthropic` or `claude` | `sk-ant-` | Claude 3.5, Claude 4, etc. |
 | Google | `gemini` | | Gemini Pro, etc. |
 | Azure OpenAI | `azureopenai` | | Requires `HB_ENDPOINT` with `?api-version=` |
 | Grok (xAI) | `grok` | | |

--- a/humanbound_cli/engine/llm/__init__.py
+++ b/humanbound_cli/engine/llm/__init__.py
@@ -4,6 +4,19 @@
 
 SUPPORTED_PROVIDERS = ["openai", "claude", "gemini", "grok", "azureopenai", "ollama"]
 
+PROVIDER_ALIASES = {"anthropic": "claude"}
+
+
+def resolve_provider_name(name) -> str:
+    """Normalize a user-supplied provider name to its canonical form.
+
+    Trims whitespace, lowercases (env vars like HB_PROVIDER=Anthropic are
+    common), and maps aliases to canonical names. Unknown names pass through
+    unchanged so the caller can raise with the original input visible.
+    """
+    name = (name or "").strip().lower()
+    return PROVIDER_ALIASES.get(name, name)
+
 
 def get_llm_pinger(model_provider):
     """Return an LLMPinger instance for the given provider.
@@ -15,7 +28,8 @@ def get_llm_pinger(model_provider):
     Returns:
         LLMPinger instance with ping(system_p, user_p, max_tokens, temperature) method.
     """
-    name = model_provider["name"] if isinstance(model_provider, dict) else model_provider.name
+    raw = model_provider["name"] if isinstance(model_provider, dict) else model_provider.name
+    name = resolve_provider_name(raw)
 
     if name == "azureopenai":
         from .azureopenai import LLMPinger
@@ -30,6 +44,10 @@ def get_llm_pinger(model_provider):
     elif name == "ollama":
         from .ollama import LLMPinger
     else:
-        raise ValueError(f"Unsupported LLM provider: {name}. Supported: {SUPPORTED_PROVIDERS}")
+        aliases = ", ".join(f"{a} -> {c}" for a, c in PROVIDER_ALIASES.items())
+        raise ValueError(
+            f"Unsupported LLM provider: {raw}. "
+            f"Supported: {SUPPORTED_PROVIDERS} (aliases: {aliases})"
+        )
 
     return LLMPinger(model_provider)

--- a/tests/unit/test_llm_pinger.py
+++ b/tests/unit/test_llm_pinger.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Tests for the LLM pinger factory: provider name resolution and aliases."""
+
+import pytest
+
+from humanbound_cli.engine.llm import (
+    PROVIDER_ALIASES,
+    SUPPORTED_PROVIDERS,
+    get_llm_pinger,
+    resolve_provider_name,
+)
+
+
+class TestResolveProviderName:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("anthropic", "claude"),  # the alias (#53)
+            ("Anthropic", "claude"),  # case-insensitive
+            ("ANTHROPIC", "claude"),
+            (" anthropic ", "claude"),  # env vars carry stray whitespace
+            ("claude", "claude"),  # canonical names pass through
+            ("OpenAI", "openai"),
+            ("ollama", "ollama"),
+            ("bogus", "bogus"),  # unknown passes through for the error path
+            ("", ""),
+            (None, ""),
+        ],
+    )
+    def test_resolution(self, raw, expected):
+        assert resolve_provider_name(raw) == expected
+
+    def test_every_alias_targets_a_supported_provider(self):
+        for alias, canonical in PROVIDER_ALIASES.items():
+            assert canonical in SUPPORTED_PROVIDERS
+            assert alias not in SUPPORTED_PROVIDERS  # alias must not shadow a real name
+
+
+class TestGetLlmPinger:
+    def test_unsupported_provider_raises_with_alias_hint(self):
+        with pytest.raises(ValueError, match=r"Unsupported LLM provider: not-real") as exc:
+            get_llm_pinger({"name": "not-real", "integration": {}})
+        assert "anthropic -> claude" in str(exc.value)
+
+    def test_error_reports_the_original_input(self):
+        # The message must show what the user typed, not a normalized form.
+        with pytest.raises(ValueError, match=r"Unsupported LLM provider: Not-Real"):
+            get_llm_pinger({"name": "Not-Real", "integration": {}})
+
+    def test_anthropic_alias_is_not_rejected_as_unsupported(self):
+        # Building the pinger may fail if the anthropic SDK isn't installed,
+        # but the alias must never be rejected as an unsupported provider.
+        try:
+            get_llm_pinger({"name": "anthropic", "integration": {"api_key": "x"}})
+        except ValueError as e:
+            pytest.fail(f"alias was rejected: {e}")
+        except Exception:
+            pass  # missing SDK etc. — the alias resolved, which is what we test
+
+
+class TestAliasReachesClaudePinger:
+    def test_anthropic_returns_the_claude_pinger(self):
+        pytest.importorskip("anthropic")  # SDK ships in the [engine] extra
+        pinger = get_llm_pinger({"name": "anthropic", "integration": {"api_key": "x"}})
+        assert type(pinger).__module__ == "humanbound_cli.engine.llm.claude"


### PR DESCRIPTION
## Summary

`HB_PROVIDER=anthropic` failed with `Unsupported LLM provider` even though the README advertises the "Anthropic" provider and the SDK dependency is the `anthropic` package. Reproduced on current `main`.

Provider names are now normalized in a single `resolve_provider_name()` (trim, lowercase, alias lookup), so `anthropic`, `Anthropic`, and stray-whitespace env values all resolve to the `claude` pinger — verified down to the returned pinger class. The `Unsupported LLM provider` error now also lists the aliases and echoes the user's original input. Only accepts *more* than before; no existing value changes meaning.

Supersedes #56 — same alias-table design as @jeremyinfomy's closed PR (blocked by the since-removed CLA), extended with case/whitespace normalization, the self-documenting error, SDK-independent resolver tests, and a CHANGELOG entry.

Out of scope: `hb providers` (`commands/providers.py`) keeps its own platform-side list with different semantics (`custom`, no `ollama`) — flagging rather than touching it here.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai`
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #53. Supersedes #56.