### PR TITLE
fix(engine): stop following redirects on auth-bearing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`pip install -e .`); previously only `HUMANBOUND_DEV=1` disabled development
   runs.
 
+### Security
+- **Credential leak on redirect (CWE-522).** A malicious or compromised target
+  endpoint could cause the engine to disclose the operator's agent auth
+  credential by returning an HTTP/WebSocket redirect. Fixed by refusing redirects
+  on all target-agent and telemetry transports; upgrading is recommended.
+  Endpoints that legitimately relied on a redirect must now be configured with
+  their final URL.
+
 ## [2.6.0] — 2026-07-09
 
 ### Removed

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -8,6 +8,7 @@ import re
 import ssl
 import time
 import traceback
+from urllib.parse import urlparse
 
 import certifi
 import httpx
@@ -51,6 +52,20 @@ def truncate(match):
     if len(url) > MIN_URL_LENGTH:
         return url[:MIN_URL_LENGTH] + "..."
     return url
+
+
+def _raise_if_redirect(resp):
+    """Reject a redirect instead of following it: requests/httpx only strip
+    Authorization on a cross-origin redirect, so a custom-named auth header
+    (see __prepare_headers) would otherwise be re-sent to the new host."""
+    if not resp.is_redirect:
+        return
+    location = resp.headers.get("location", "")
+    host = urlparse(location).hostname or location or "unknown"
+    raise Exception(
+        f"{resp.status_code}/Endpoint returned a redirect to '{host}'. Redirects are "
+        "not followed for security reasons; set your config endpoint to the final URL."
+    )
 
 
 #
@@ -361,10 +376,23 @@ class Bot(ResponseExtractor):
         payload = self.__prepare_payload(payload1, base_payload, u_prompt, conversation)
         t_start = time.time()
 
-        resp = requests.post(endpoint, headers=headers, json=payload, timeout=REQUESTS_TIMEOUT)
+        resp = requests.post(
+            endpoint,
+            headers=headers,
+            json=payload,
+            timeout=REQUESTS_TIMEOUT,
+            allow_redirects=False,
+        )
         if resp.status_code == 405:
             t_start = time.time()
-            resp = requests.get(endpoint, headers=headers, params=payload, timeout=REQUESTS_TIMEOUT)
+            resp = requests.get(
+                endpoint,
+                headers=headers,
+                params=payload,
+                timeout=REQUESTS_TIMEOUT,
+                allow_redirects=False,
+            )
+        _raise_if_redirect(resp)
         if resp.status_code != 200 and resp.status_code != 201:
             raise Exception(
                 f"{resp.status_code}/{resp.text} - {url_pattern.sub(truncate, endpoint)}"
@@ -475,23 +503,34 @@ class Bot(ResponseExtractor):
             payload = self.__prepare_payload(payload, base_payload, u_prompt, conversation)
 
             try:
-                from websockets.asyncio.client import connect
+                import websockets.asyncio.client as ws_client
+                from websockets.exceptions import SecurityError
             except ImportError as e:
                 raise ImportError(
                     "Streaming bots require the [engine] extra. "
                     "Install with: pip install humanbound[engine]"
                 ) from e
 
-            async with connect(
-                endpoint,
-                open_timeout=REQUESTS_TIMEOUT,
-                ping_timeout=REQUESTS_TIMEOUT,
-                close_timeout=REQUESTS_TIMEOUT,
-                ssl=ssl_context,
-                additional_headers=headers,
-            ) as websocket:
-                await websocket.send(json.dumps(payload, ensure_ascii=False))
-                message, exec_t = await self.__listen(websocket)
+            # websockets strips no auth header on redirect and has no per-call
+            # toggle; cap the module budget so only the initial handshake is sent.
+            ws_client.MAX_REDIRECTS = 1
+
+            try:
+                async with ws_client.connect(
+                    endpoint,
+                    open_timeout=REQUESTS_TIMEOUT,
+                    ping_timeout=REQUESTS_TIMEOUT,
+                    close_timeout=REQUESTS_TIMEOUT,
+                    ssl=ssl_context,
+                    additional_headers=headers,
+                ) as websocket:
+                    await websocket.send(json.dumps(payload, ensure_ascii=False))
+                    message, exec_t = await self.__listen(websocket)
+            except SecurityError as e:
+                raise Exception(
+                    "3xx/WebSocket endpoint attempted a redirect, which is not followed "
+                    "for security reasons; set your config endpoint to the final URL."
+                ) from e
 
             # NOTE: Streaming mode doesn't support per-turn metadata extraction
             # since chunks are processed incrementally and final response object isn't available
@@ -532,7 +571,7 @@ class Bot(ResponseExtractor):
             async with httpx.AsyncClient(
                 timeout=REQUESTS_TIMEOUT,
                 verify=ssl_context,
-                follow_redirects=True,
+                follow_redirects=False,
             ) as client:
                 async with client.stream(
                     "POST",
@@ -540,6 +579,7 @@ class Bot(ResponseExtractor):
                     headers=headers,
                     json=payload,
                 ) as resp:
+                    _raise_if_redirect(resp)
                     resp.raise_for_status()
                     async for line in resp.aiter_lines():
                         if not line.startswith("data:"):
@@ -715,10 +755,23 @@ class Telemetry:
         method = self.config.get("method", "GET").upper()
 
         if method == "POST":
-            resp = requests.post(endpoint, headers=headers, json=payload, timeout=REQUESTS_TIMEOUT)
+            resp = requests.post(
+                endpoint,
+                headers=headers,
+                json=payload,
+                timeout=REQUESTS_TIMEOUT,
+                allow_redirects=False,
+            )
         else:  # GET
-            resp = requests.get(endpoint, headers=headers, params=payload, timeout=REQUESTS_TIMEOUT)
+            resp = requests.get(
+                endpoint,
+                headers=headers,
+                params=payload,
+                timeout=REQUESTS_TIMEOUT,
+                allow_redirects=False,
+            )
 
+        _raise_if_redirect(resp)
         if resp.status_code != 200 and resp.status_code != 201:
             raise Exception(
                 f"{resp.status_code}/{resp.text} - {url_pattern.sub(truncate, endpoint)}"

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -14,7 +14,7 @@ parser tests would live alongside their respective real fixtures.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,6 +22,7 @@ from humanbound_cli.engine.bot import (
     Bot,
     ResponseExtractor,
     Telemetry,
+    _raise_if_redirect,
 )
 
 # ────────────────────────────────────────────────────────────────
@@ -53,10 +54,12 @@ def bot(bot_config):
     return Bot(bot_config, e_id="exp-abc")
 
 
-def _mock_post(status=200, payload=None, text=""):
+def _mock_post(status=200, payload=None, text="", is_redirect=False, location=None):
     r = MagicMock()
     r.status_code = status
     r.text = text
+    r.is_redirect = is_redirect
+    r.headers = {"location": location} if location else {}
     r.json = MagicMock(return_value=payload or {})
     return r
 
@@ -480,3 +483,88 @@ def test_telemetry_has_no_data_returns_true_for_empty():
     # Smoke-check: does not raise for standard inputs.
     result = t._has_telemetry_data({})
     assert isinstance(result, bool)
+
+
+# ────────────────────────────────────────────────────────────────
+# Redirect credential-leak guard
+# ────────────────────────────────────────────────────────────────
+
+
+def test_raise_if_redirect_handles_missing_location():
+    with pytest.raises(Exception, match="not followed for security"):
+        _raise_if_redirect(_mock_post(status=307, is_redirect=True))
+
+
+def test_make_api_call_rejects_redirect_and_disables_following(bot):
+    redirect = _mock_post(status=302, is_redirect=True, location="https://evil.example/steal")
+    with patch("humanbound_cli.engine.bot.requests.post", return_value=redirect) as post:
+        with pytest.raises(Exception, match=r"evil\.example"):
+            bot._Bot__make_api_call({}, "https://agent.example/chat", {}, {"m": "x"})
+    assert post.call_args.kwargs.get("allow_redirects") is False
+
+
+def test_make_api_call_rejects_redirect_on_405_get_fallback(bot):
+    post_405 = _mock_post(status=405)
+    get_302 = _mock_post(status=302, is_redirect=True, location="https://evil.example/steal")
+    with (
+        patch("humanbound_cli.engine.bot.requests.post", return_value=post_405),
+        patch("humanbound_cli.engine.bot.requests.get", return_value=get_302) as get,
+    ):
+        with pytest.raises(Exception, match="not followed for security"):
+            bot._Bot__make_api_call({}, "https://agent.example/chat", {}, {"m": "x"})
+    assert get.call_args.kwargs.get("allow_redirects") is False
+
+
+def test_make_api_call_allows_normal_2xx(bot):
+    ok = _mock_post(status=200, payload={"content": "hi"})
+    with patch("humanbound_cli.engine.bot.requests.post", return_value=ok):
+        data, _, _ = bot._Bot__make_api_call({}, "https://agent.example/chat", {}, {"m": "x"})
+    assert data == {"content": "hi"}
+
+
+def test_telemetry_make_api_call_rejects_redirect():
+    tel = Telemetry(
+        {"endpoint": "https://tele.example/fetch", "headers": {}, "payload": {}, "method": "POST"},
+        e_id="e1",
+    )
+    redirect = _mock_post(status=302, is_redirect=True, location="https://evil.example/steal")
+    with patch("humanbound_cli.engine.bot.requests.post", return_value=redirect) as post:
+        with pytest.raises(Exception, match="not followed for security"):
+            tel._Telemetry__make_api_call({}, "https://tele.example/fetch", {}, {})
+    assert post.call_args.kwargs.get("allow_redirects") is False
+
+
+def _async_cm(enter_value):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=enter_value)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def test_stream_sse_rejects_redirect_and_disables_following(bot):
+    redirect_resp = MagicMock()
+    redirect_resp.is_redirect = True
+    redirect_resp.status_code = 302
+    redirect_resp.headers = {"location": "https://evil.example/steal"}
+
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_async_cm(redirect_resp))
+
+    with patch("humanbound_cli.engine.bot.httpx.AsyncClient", return_value=_async_cm(client)) as ac:
+        with pytest.raises(Exception, match="not followed for security"):
+            asyncio.run(bot._Bot__stream_sse({}, "hi"))
+    assert ac.call_args.kwargs.get("follow_redirects") is False
+
+
+def test_stream_websocket_blocks_handshake_redirect(bot):
+    import websockets.asyncio.client as wsc
+    from websockets.exceptions import SecurityError
+
+    def _boom(*a, **k):
+        raise SecurityError("more than 1 redirects")
+
+    with patch.object(wsc, "connect", side_effect=_boom):
+        with pytest.raises(Exception, match="not followed for security"):
+            asyncio.run(bot._Bot__stream({}, "hi"))
+    # module-level redirect budget capped to the initial handshake
+    assert wsc.MAX_REDIRECTS == 1


### PR DESCRIPTION
## Summary

Following an HTTP/WebSocket redirect on a request that carries the target agent's auth credential could re-send that credential to a host chosen by the (untrusted) endpoint: `requests`/`httpx` strip only `Authorization` on a cross-origin redirect, and `websockets` strips nothing.

This refuses redirects on every transport that carries the credential, via a shared guard:
- `allow_redirects=False` on the REST and telemetry `requests` calls
- `follow_redirects=False` on the SSE `httpx` client
- `MAX_REDIRECTS=1` on the WebSocket handshake (no per-call toggle exists)

A `30x` response now raises a clear error naming the redirect host.

**Behavior change:** endpoints that legitimately relied on a redirect (trailing-slash normalization, `http→https`, CDN/load-balancer hops) will now error instead of silently following, and must be configured with their final URL. All non-redirecting endpoints are unaffected.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- Reported privately per SECURITY.md; tracked in the private advisory. No public issue. -->
