### PR TITLE
feat(telemetry): send one-time telemetry_disabled event on opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Telemetry: one-time opt-out event.** Disabling telemetry — via
+  `hb telemetry disable`, `DO_NOT_TRACK=1`, or `HB_TELEMETRY_DISABLED=1` —
+  now sends a single, final `telemetry_disabled` event (at most once per
+  machine, ever) so opt-outs can be counted. Env-var opt-outs are sent under
+  a fresh one-shot random ID with geolocation and person profiles disabled;
+  CI, dev installs, and non-TTY runs never send it. This is a deliberate,
+  documented deviation from the `DO_NOT_TRACK` convention — see
+  `PRIVACY.md` ("How to disable").
 - **Telemetry: IP-based geolocation.** CLI and docs-site analytics now derive an
   approximate location (country, region, city, and coarse coordinates) from the
   request IP via PostHog GeoIP enrichment; the raw IP is discarded after

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,6 +43,10 @@ This document does **NOT** cover:
   person property.
 - Disable with `hb telemetry disable`, `HB_TELEMETRY_DISABLED=1`, or
   `DO_NOT_TRACK=1`.
+- When telemetry is turned off — by any mechanism, **including
+  `DO_NOT_TRACK=1`** — a single, final `telemetry_disabled` event is sent, at
+  most once per machine ever, so we can count opt-outs. See
+  [How to disable](#how-to-disable).
 - Automatically disabled in CI, editable dev installs, and when stdout is
   piped (non-TTY).
 - Data goes to PostHog EU Cloud and is retained for 1 year.
@@ -79,7 +83,7 @@ account **email** as a PostHog person property (`$set: { email }`), read
 locally from `~/.humanbound/credentials.json`. Anonymous, pre-login events
 never carry an email.
 
-The seven events:
+The eight events:
 
 | Event | When it fires | Event-specific properties |
 |---|---|---|
@@ -90,6 +94,7 @@ The seven events:
 | `posture_view` | When posture is rendered | `is_local`, `mode`, `has_coverage` |
 | `findings_view` | When findings list is rendered | `filter_applied` |
 | `gated_command_hit` | When a platform-only feature is attempted without login | `command` (e.g. `hb monitor`) |
+| `telemetry_disabled` | Once per machine ever, when telemetry is disabled — at `hb telemetry disable`, or on the first run with `DO_NOT_TRACK=1` / `HB_TELEMETRY_DISABLED=1` set | `reason` (`command`, `DO_NOT_TRACK`, `HB_TELEMETRY_DISABLED`, `opt_out_state`) |
 
 ## What we don't collect
 
@@ -142,6 +147,36 @@ export HB_TELEMETRY_DISABLED=1        # One shell session
 export DO_NOT_TRACK=1                 # Honored by many CLIs (see consoledonottrack.com)
 ```
 
+### The one-time opt-out event
+
+When telemetry on a machine is disabled, the CLI sends a **single, final
+`telemetry_disabled` event** so we can count how many installations opt out.
+It fires at most **once per machine, ever** — tracked by a
+`disabled_ping_sent` flag in `~/.humanbound/telemetry.json` — and applies to
+all three mechanisms above. We know the `DO_NOT_TRACK` convention reads
+"send nothing at all"; this event is a deliberate, documented exception to
+it, limited to the properties below.
+
+- **Properties:** the disable `reason` (`command`, `DO_NOT_TRACK`,
+  `HB_TELEMETRY_DISABLED`, or `opt_out_state`), the CLI version, and
+  `source: cli`. Nothing else.
+- **Identity (env-var opt-outs):** a fresh one-shot random ID
+  (`tlm_optout_<uuid>`) that is never stored and never linked to the machine
+  UUID or any account. IP geolocation and person-profile creation are
+  disabled for this event, and no email is ever attached.
+- **Identity (`hb telemetry disable`):** the event is sent at the moment you
+  run the command — while telemetry is still enabled — under the machine's
+  normal identity, like any other event.
+- **Fail closed:** if the flag cannot be written (e.g. read-only home
+  directory), the event is **not** sent — "at most once" wins over capturing
+  it.
+- It never fires from CI, dev installs, or non-interactive (non-TTY) runs —
+  scripts and containers stay silent; only interactive terminal sessions are
+  counted.
+
+After that single event, the machine is silent: nothing further is sent
+unless you explicitly re-enable telemetry.
+
 Check current state:
 
 ```bash
@@ -156,14 +191,20 @@ hb telemetry enable
 
 ## Auto-disabled environments
 
-Telemetry is automatically off (no event is sent, no UUID is generated) in
-any of:
+Telemetry is automatically off in any of:
 
 - CI environments: `CI`, `GITHUB_ACTIONS`, `BUILDKITE`, `JENKINS_HOME`,
   `TF_BUILD`, `GITLAB_CI`, `CIRCLECI`, `TRAVIS`
 - Editable dev installs of this repo, or when `HUMANBOUND_DEV=1`
 - When `stdout` is not a TTY (piped or redirected output)
-- When `DO_NOT_TRACK=1` or `HB_TELEMETRY_DISABLED=1` is set
+
+In these environments the CLI is **fully silent**: no event is sent, no UUID
+is generated, and the one-time `telemetry_disabled` event is not sent either.
+
+Setting `DO_NOT_TRACK=1` or `HB_TELEMETRY_DISABLED=1` also disables
+telemetry, with one documented exception — the
+[one-time opt-out event](#the-one-time-opt-out-event) (which is itself
+suppressed in the CI/dev environments above).
 
 ## Data destination and retention
 
@@ -259,9 +300,10 @@ forgotten" for anonymous data is to:
 1. Delete your local `~/.humanbound/telemetry.json` file
 2. Run `hb telemetry disable` to prevent further events
 
-After those two steps, no further anonymous events from your machine reach
-PostHog, and the historical anonymous events cannot be associated with you
-by us or by PostHog.
+Running `hb telemetry disable` sends one final `telemetry_disabled` event
+(see [How to disable](#how-to-disable)). After those two steps, no further
+anonymous events from your machine reach PostHog, and the historical
+anonymous events cannot be associated with you by us or by PostHog.
 
 ## Changes to this policy
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ loop, release process, and DCO sign-off requirement (see [DCO.md](https://github
 
 The `hb` CLI sends anonymous usage data to help us improve it.
 Disable with `hb telemetry disable`, `HB_TELEMETRY_DISABLED=1`, or
-`DO_NOT_TRACK=1`. Full disclosure: [PRIVACY.md](https://github.com/humanbound/humanbound/blob/main/PRIVACY.md).
+`DO_NOT_TRACK=1`. Turning telemetry off sends one final anonymous
+`telemetry_disabled` event (once per machine, ever) so we can count
+opt-outs. Full disclosure: [PRIVACY.md](https://github.com/humanbound/humanbound/blob/main/PRIVACY.md).
 
 ## License
 

--- a/humanbound_cli/commands/telemetry.py
+++ b/humanbound_cli/commands/telemetry.py
@@ -5,6 +5,7 @@
 import click
 from rich.console import Console
 
+from .. import telemetry as telemetry_pkg
 from ..telemetry import consent
 
 console = Console()
@@ -35,13 +36,35 @@ def telemetry_enable():
     )
 
 
+def _fire_final_optout_event() -> bool:
+    """Send the once-ever `telemetry_disabled` event while telemetry is still
+    enabled, gated on the shared `disabled_ping_sent` flag. Returns whether
+    the event was sent."""
+    if not consent.is_enabled() or consent.disabled_ping_already_sent():
+        return False
+    if not consent.mark_disabled_ping_sent():
+        return False
+    telemetry_pkg.capture("telemetry_disabled", {"reason": "command"})
+    return True
+
+
 @telemetry_group.command("disable")
 def telemetry_disable():
     """Disable telemetry on this machine."""
+    fired = _fire_final_optout_event()
     consent.write_opt_out()
     consent.reset_cache()
     console.print("[yellow]Telemetry disabled.[/yellow]")
-    console.print("No events will be sent from this machine.")
+    console.print(
+        "A final [bold]telemetry_disabled[/bold] event was sent so we can "
+        "count opt-outs; nothing further will be sent from this machine."
+        if fired
+        else "No events will be sent from this machine."
+    )
+    console.print(
+        "Details: [link=https://github.com/humanbound/humanbound/blob/main/PRIVACY.md]"
+        "PRIVACY.md[/link]"
+    )
 
 
 @telemetry_group.command("status")

--- a/humanbound_cli/main.py
+++ b/humanbound_cli/main.py
@@ -199,7 +199,7 @@ def main():
     """Entrypoint with session expiry handling and telemetry init."""
     from .exceptions import NotAuthenticatedError, SessionExpiredError
 
-    telemetry_pkg.maybe_fire_install_event()
+    telemetry_pkg.maybe_fire_startup_events()
     atexit.register(telemetry_pkg.shutdown)
 
     try:

--- a/humanbound_cli/telemetry/__init__.py
+++ b/humanbound_cli/telemetry/__init__.py
@@ -14,7 +14,14 @@ Public API:
 """
 
 from . import consent as _consent
-from .client import capture, identify, identify_from_credentials, is_enabled, shutdown
+from .client import (
+    capture,
+    capture_disabled_ping,
+    identify,
+    identify_from_credentials,
+    is_enabled,
+    shutdown,
+)
 
 
 def fire_gated_command_hit() -> None:
@@ -67,12 +74,51 @@ def _print_first_run_notice() -> None:
 
         click.echo(
             "humanbound: anonymous usage data is enabled to help improve the CLI. "
-            "No personal data is sent. Disable with `hb telemetry disable`. "
+            "No personal data is sent. Disable with `hb telemetry disable` "
+            "(disabling sends a single, final opt-out event). "
             "Details: https://github.com/humanbound/humanbound/blob/main/PRIVACY.md",
             err=True,
         )
     except Exception:
         pass
+
+
+def maybe_fire_disabled_ping(argv: list[str] | None = None) -> None:
+    """Fire the once-ever `telemetry_disabled` event when telemetry is off
+    because of DO_NOT_TRACK, HB_TELEMETRY_DISABLED, or a pre-existing opt-out.
+
+    Interactive (TTY) runs only — containers and scripts get a fresh HOME per
+    run, so a headless ping would fire once per container instead of once per
+    machine. Never fires in CI, dev mode, or editable installs, never fires
+    twice per machine (`disabled_ping_sent` in telemetry.json), and skips
+    `hb telemetry` subcommands. If the flag cannot be persisted the event is
+    not sent — "at most once" wins over capturing it. Never raises.
+    """
+    try:
+        import sys
+
+        argv = argv if argv is not None else sys.argv
+        if len(argv) >= 2 and argv[1] == "telemetry":
+            return
+        if not sys.stdout.isatty():
+            return
+        if _consent.is_enabled() or _consent.is_dev_or_ci_environment():
+            return
+        reason = _consent.disabled_ping_reason()
+        if reason is None or _consent.disabled_ping_already_sent():
+            return
+        if _consent.mark_disabled_ping_sent():
+            capture_disabled_ping(reason)
+    except Exception:
+        pass
+
+
+def maybe_fire_startup_events(argv: list[str] | None = None) -> None:
+    """Fire the startup events: `install` on the first enabled run, or the
+    once-ever `telemetry_disabled` ping when telemetry is off. The two are
+    mutually exclusive — each no-ops unless its condition holds."""
+    maybe_fire_install_event(argv)
+    maybe_fire_disabled_ping(argv)
 
 
 __all__ = [
@@ -81,6 +127,8 @@ __all__ = [
     "identify",
     "identify_from_credentials",
     "is_enabled",
+    "maybe_fire_disabled_ping",
     "maybe_fire_install_event",
+    "maybe_fire_startup_events",
     "shutdown",
 ]

--- a/humanbound_cli/telemetry/client.py
+++ b/humanbound_cli/telemetry/client.py
@@ -10,6 +10,7 @@ sites only specify event-specific properties on top of these.
 import base64
 import json
 import threading
+import uuid
 from pathlib import Path
 
 import posthog as _posthog
@@ -148,6 +149,30 @@ def capture(event: str, properties: dict | None = None) -> None:
         )
     except Exception:
         # Telemetry must never break the CLI. Swallow.
+        pass
+
+
+def capture_disabled_ping(reason: str) -> None:
+    """Send the once-ever `telemetry_disabled` event for a machine whose
+    telemetry is off — the only send path that skips the consent check,
+    disclosed in PRIVACY.md. One-shot random id, no geolocation, no person
+    profile, no account identity. Never raises.
+    """
+    try:
+        if not _ensure_init():
+            return
+        _posthog.capture(
+            distinct_id=f"tlm_optout_{uuid.uuid4()}",
+            event="telemetry_disabled",
+            properties={
+                "source": "cli",
+                "hb_version": __version__,
+                "reason": reason,
+                "$geoip_disable": True,
+                "$process_person_profile": False,
+            },
+        )
+    except Exception:
         pass
 
 

--- a/humanbound_cli/telemetry/consent.py
+++ b/humanbound_cli/telemetry/consent.py
@@ -152,3 +152,44 @@ def clear_opt_out() -> None:
         state["id"] = f"tlm_{uuid.uuid4()}"
     state["opted_out"] = False
     _write_state(state)
+
+
+def is_dev_or_ci_environment() -> bool:
+    """True in CI, dev mode, or editable installs — machines that are not
+    real users and must never be counted, not even by the disabled ping."""
+    if any(os.environ.get(v) for v in _CI_ENV_VARS):
+        return True
+    if os.environ.get("HUMANBOUND_DEV") == "1":
+        return True
+    return _is_editable_install()
+
+
+def disabled_ping_reason() -> str | None:
+    """Ping-eligible disable reason, or None.
+
+    Mirrors the first three checks of _compute(); CI, dev-mode, editable, and
+    non-TTY disables are not ping-eligible.
+    """
+    if os.environ.get("DO_NOT_TRACK") == "1":
+        return "DO_NOT_TRACK"
+    if os.environ.get("HB_TELEMETRY_DISABLED") == "1":
+        return "HB_TELEMETRY_DISABLED"
+    if _read_state().get("opted_out") is True:
+        return "opt_out_state"
+    return None
+
+
+def disabled_ping_already_sent() -> bool:
+    return _read_state().get("disabled_ping_sent") is True
+
+
+def mark_disabled_ping_sent() -> bool:
+    """Persist the once-ever flag. Returns False if the write failed — the
+    caller must then skip the send so the event can never fire twice."""
+    try:
+        state = _read_state()
+        state["disabled_ping_sent"] = True
+        _write_state(state)
+        return True
+    except Exception:
+        return False

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -858,3 +858,371 @@ def test_first_run_notice_does_not_print_when_disabled(monkeypatch, capfd):
 
     captured = capfd.readouterr()
     assert "PRIVACY.md" not in captured.err
+
+
+# === Section 9 — telemetry_disabled ping: consent helpers ===
+
+
+@pytest.mark.parametrize("var", ["DO_NOT_TRACK", "HB_TELEMETRY_DISABLED"])
+def test_disabled_ping_reason_env_vars(monkeypatch, var):
+    monkeypatch.setenv(var, "1")
+    assert consent.disabled_ping_reason() == var
+
+
+def test_disabled_ping_reason_opt_out_state(tmp_path):
+    _write_state(tmp_path, {"id": "tlm_x", "opted_out": True})
+    assert consent.disabled_ping_reason() == "opt_out_state"
+
+
+def test_disabled_ping_reason_none_on_clean_machine():
+    assert consent.disabled_ping_reason() is None
+
+
+def test_disabled_ping_reason_none_for_non_tty_only(monkeypatch):
+    # Non-TTY disables telemetry but is not a user choice — not ping-eligible.
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    assert consent.disabled_ping_reason() is None
+
+
+def test_disabled_ping_reason_priority_matches_compute(monkeypatch, tmp_path):
+    # DO_NOT_TRACK wins over HB var and opt-out state, matching _compute() order.
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv("HB_TELEMETRY_DISABLED", "1")
+    _write_state(tmp_path, {"id": "tlm_x", "opted_out": True})
+    assert consent.disabled_ping_reason() == "DO_NOT_TRACK"
+
+
+def test_disabled_ping_flag_roundtrip(tmp_path):
+    assert consent.disabled_ping_already_sent() is False
+    assert consent.mark_disabled_ping_sent() is True
+    assert consent.disabled_ping_already_sent() is True
+    state = _read_state(tmp_path)
+    assert state.get("disabled_ping_sent") is True
+
+
+def test_mark_disabled_ping_preserves_existing_state(tmp_path):
+    _write_state(tmp_path, {"id": "tlm_keep", "opted_out": True})
+    assert consent.mark_disabled_ping_sent() is True
+    state = _read_state(tmp_path)
+    assert state == {"id": "tlm_keep", "opted_out": True, "disabled_ping_sent": True}
+
+
+def test_mark_disabled_ping_creates_no_uuid(tmp_path):
+    # A DO_NOT_TRACK-from-first-run machine must not get a machine UUID.
+    assert consent.mark_disabled_ping_sent() is True
+    state = _read_state(tmp_path)
+    assert "id" not in state
+
+
+def test_mark_disabled_ping_returns_false_on_write_failure(monkeypatch):
+    def boom(state):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(consent, "_write_state", boom)
+    assert consent.mark_disabled_ping_sent() is False
+
+
+# === Section 10 — telemetry_disabled ping: client sender ===
+
+
+def test_capture_disabled_ping_sends_minimal_event(monkeypatch, mock_posthog):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+
+    client.capture_disabled_ping("DO_NOT_TRACK")
+
+    assert mock_posthog.capture.call_count == 1
+    call = mock_posthog.capture.call_args
+    assert re.match(r"^tlm_optout_[0-9a-f-]{36}$", call.kwargs["distinct_id"])
+    assert call.kwargs["event"] == "telemetry_disabled"
+    props = call.kwargs["properties"]
+    assert props["reason"] == "DO_NOT_TRACK"
+    assert props["source"] == "cli"
+    assert "hb_version" in props
+    assert props["$geoip_disable"] is True
+    assert props["$process_person_profile"] is False
+    # Minimal property set — nothing beyond these keys.
+    assert set(props) == {
+        "reason",
+        "source",
+        "hb_version",
+        "$geoip_disable",
+        "$process_person_profile",
+    }
+
+
+def test_capture_disabled_ping_fresh_id_each_call(mock_posthog):
+    client.capture_disabled_ping("DO_NOT_TRACK")
+    client.capture_disabled_ping("DO_NOT_TRACK")
+    ids = [c.kwargs["distinct_id"] for c in mock_posthog.capture.call_args_list]
+    assert ids[0] != ids[1]
+
+
+def test_capture_disabled_ping_never_attaches_email(tmp_path, mock_posthog):
+    _write_credentials_with_user_id_and_email(tmp_path, "auth0|user123", "dev@example.com")
+    client.capture_disabled_ping("HB_TELEMETRY_DISABLED")
+    props = mock_posthog.capture.call_args.kwargs["properties"]
+    assert "$set" not in props
+    assert mock_posthog.capture.call_args.kwargs["distinct_id"].startswith("tlm_optout_")
+
+
+def test_capture_disabled_ping_swallows_exceptions(mock_posthog):
+    mock_posthog.capture.side_effect = RuntimeError("network down")
+    client.capture_disabled_ping("DO_NOT_TRACK")
+
+
+# === Section 11 — telemetry_disabled ping: startup orchestration ===
+
+
+def _capture_ping_calls(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "humanbound_cli.telemetry.capture_disabled_ping",
+        lambda reason: calls.append(reason),
+    )
+    return calls
+
+
+@pytest.mark.parametrize("var", ["DO_NOT_TRACK", "HB_TELEMETRY_DISABLED"])
+def test_ping_fires_for_env_var(monkeypatch, tmp_path, var):
+    monkeypatch.setenv(var, "1")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == [var]
+    state = _read_state(tmp_path)
+    assert state.get("disabled_ping_sent") is True
+    assert "id" not in state  # no machine UUID generated
+
+
+def test_ping_fires_for_preexisting_opt_out(monkeypatch, tmp_path):
+    _write_state(tmp_path, {"id": "tlm_old", "opted_out": True})
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == ["opt_out_state"]
+    assert _read_state(tmp_path).get("disabled_ping_sent") is True
+
+
+def test_ping_does_not_fire_when_enabled(monkeypatch, tmp_path):
+    calls = _capture_ping_calls(monkeypatch)
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+    assert calls == []
+    assert not _telemetry_file(tmp_path).exists()
+
+
+def test_ping_fires_only_once(monkeypatch, tmp_path):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == ["DO_NOT_TRACK"]
+
+
+@pytest.mark.parametrize("ci_var", ["CI", "GITHUB_ACTIONS", "GITLAB_CI"])
+def test_ping_suppressed_in_ci(monkeypatch, tmp_path, ci_var):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv(ci_var, "true")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+    assert not _telemetry_file(tmp_path).exists()
+
+
+def test_ping_suppressed_in_dev_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv("HUMANBOUND_DEV", "1")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+
+
+def test_ping_suppressed_in_editable_install(monkeypatch, tmp_path):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setattr(consent, "_is_editable_install", lambda: True)
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+
+
+def test_ping_suppressed_for_non_tty_only(monkeypatch, tmp_path):
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+    assert not _telemetry_file(tmp_path).exists()
+
+
+def test_ping_requires_tty_even_with_env_var(monkeypatch, tmp_path):
+    # Containers/scripts get a fresh HOME per run, so a non-TTY ping would
+    # fire once per container instead of once per machine. Headless runs
+    # stay silent; only interactive users are counted.
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+    assert not _telemetry_file(tmp_path).exists()
+
+
+def test_ping_skipped_for_hb_telemetry_subcommand(monkeypatch, tmp_path):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "telemetry", "status"])
+
+    assert calls == []
+    assert not _telemetry_file(tmp_path).exists()
+
+
+def test_ping_fail_closed_when_flag_unwritable(monkeypatch, tmp_path):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+    calls = _capture_ping_calls(monkeypatch)
+
+    def boom(state):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(consent, "_write_state", boom)
+
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert calls == []
+
+
+def test_ping_never_raises(monkeypatch):
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+    monkeypatch.setattr(
+        "humanbound_cli.telemetry.capture_disabled_ping",
+        lambda reason: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+
+def test_main_fires_startup_events(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "humanbound_cli.telemetry.maybe_fire_install_event",
+        lambda argv=None: calls.append("install"),
+    )
+    monkeypatch.setattr(
+        "humanbound_cli.telemetry.maybe_fire_disabled_ping",
+        lambda argv=None: calls.append("ping"),
+    )
+    monkeypatch.setattr("humanbound_cli.main.cli", lambda **kwargs: None)
+
+    main_module.main()
+
+    assert calls == ["install", "ping"]
+
+
+# === Section 12 — telemetry_disabled ping: `hb telemetry disable` path ===
+
+
+def test_disable_fires_final_event_with_machine_identity(tmp_path, mock_posthog):
+    _prime_consent_for_clirunner()
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["disable"])
+
+    assert result.exit_code == 0
+    assert mock_posthog.capture.call_count == 1
+    call = mock_posthog.capture.call_args
+    assert call.kwargs["event"] == "telemetry_disabled"
+    assert call.kwargs["properties"]["reason"] == "command"
+    # Normal identity — the machine UUID, not a one-shot optout id.
+    assert call.kwargs["distinct_id"].startswith("tlm_")
+    assert not call.kwargs["distinct_id"].startswith("tlm_optout_")
+    state = _read_state(tmp_path)
+    assert state.get("opted_out") is True
+    assert state.get("disabled_ping_sent") is True
+    assert "final" in result.output.lower()
+
+
+def test_disable_does_not_fire_twice(tmp_path, mock_posthog):
+    _write_state(tmp_path, {"id": "tlm_x", "opted_out": False, "disabled_ping_sent": True})
+    _prime_consent_for_clirunner()
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["disable"])
+
+    assert result.exit_code == 0
+    mock_posthog.capture.assert_not_called()
+    assert _read_state(tmp_path).get("opted_out") is True
+
+
+def test_disable_when_env_disabled_sends_nothing_and_leaves_flag_unset(
+    monkeypatch, tmp_path, mock_posthog
+):
+    # Env-disabled at command time: no event now; the startup ping on a later
+    # run owns the send (with the env reason), so the flag must stay unset.
+    monkeypatch.setenv("HB_TELEMETRY_DISABLED", "1")
+    _prime_consent_for_clirunner()
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["disable"])
+
+    assert result.exit_code == 0
+    mock_posthog.capture.assert_not_called()
+    state = _read_state(tmp_path)
+    assert state.get("opted_out") is True
+    assert state.get("disabled_ping_sent") is not True
+
+
+def test_disable_then_env_var_yields_one_event_total(monkeypatch, tmp_path, mock_posthog):
+    _prime_consent_for_clirunner()
+    runner = CliRunner()
+    runner.invoke(telemetry_group, ["disable"])
+    assert mock_posthog.capture.call_count == 1
+
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    consent.reset_cache()
+    telemetry_pkg.maybe_fire_disabled_ping(argv=["hb", "test"])
+
+    assert mock_posthog.capture.call_count == 1  # still just the command event
+
+
+def test_disable_fail_closed_when_flag_unwritable(monkeypatch, mock_posthog):
+    _prime_consent_for_clirunner()
+
+    def boom(state):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(consent, "_write_state", boom)
+    runner = CliRunner()
+    runner.invoke(telemetry_group, ["disable"])
+
+    # No event when the once-ever gate cannot be persisted.
+    mock_posthog.capture.assert_not_called()
+
+
+def test_first_run_notice_mentions_final_optout_event(monkeypatch, capfd):
+    monkeypatch.setattr("humanbound_cli.telemetry.consent.is_enabled", lambda: True)
+    monkeypatch.setattr("humanbound_cli.telemetry.capture", lambda event, properties=None: None)
+
+    telemetry_pkg.maybe_fire_install_event()
+
+    captured = capfd.readouterr()
+    assert "final opt-out event" in captured.err
+    assert "PRIVACY.md" in captured.err


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Disabling telemetry (`hb telemetry disable`, `DO_NOT_TRACK=1`, or
`HB_TELEMETRY_DISABLED=1`) now sends a single, final `telemetry_disabled`
event — at most once per machine, ever — so opt-outs can be counted.

- `hb telemetry disable` fires the event at the moment the command runs
  (telemetry is still enabled), under the machine's normal identity, then
  writes the opt-out.
- Env-var opt-outs fire once at startup under a fresh one-shot random ID
  (`tlm_optout_<uuid>`), with GeoIP and person profiles disabled — never
  linked to the machine UUID or any account.
- Both paths share a `disabled_ping_sent` gate in `~/.humanbound/telemetry.json`;
  if the gate can't be persisted, nothing is sent (fail closed).
- CI, dev/editable installs, and non-TTY runs never send it, so scripts and
  ephemeral containers stay silent and can't inflate the count.
- Users who opted out before this release are counted once with
  `reason: opt_out_state` on their next interactive run.

This is a deliberate, documented deviation from the `DO_NOT_TRACK`
convention — disclosed in `PRIVACY.md` ("The one-time opt-out event"), the
first-run notice, and the `hb telemetry disable` output.

## Type of change

- [x] New feature (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (CLI usage telemetry is documented in `PRIVACY.md`, not on the docs site — no docs-site page covers it)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- none -->