### PR TITLE
chore(release): prepare v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-07-22
+
 ### Added
 - **Telemetry: one-time opt-out event.** Disabling telemetry — via
   `hb telemetry disable`, `DO_NOT_TRACK=1`, or `HB_TELEMETRY_DISABLED=1` —
@@ -497,7 +499,9 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/humanbound/humanbound/releases/tag/v2.7.0
+[2.6.0]: https://github.com/humanbound/humanbound/releases/tag/v2.6.0
 [2.5.0]: https://github.com/humanbound/humanbound/releases/tag/v2.5.0
 [2.4.0]: https://github.com/humanbound/humanbound/releases/tag/v2.4.0
 [2.3.0]: https://github.com/humanbound/humanbound/releases/tag/v2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.6.0"
+version = "2.7.0"
 description = "Open-source adversarial testing engine, SDK, and CLI for AI agents."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Prepare the v2.7.0 release: move the `[Unreleased]` entries under a dated
`## [2.7.0] — 2026-07-22` heading, refresh the comparison links at the bottom
of the changelog (adding the `[2.6.0]` link missed in the previous release),
and bump the package version in `pyproject.toml` ahead of tagging `v2.7.0`.

Headline change shipping in this release: the one-time `telemetry_disabled`
opt-out event (#81).

No code changes — after merge, tagging `v2.7.0` on main triggers the release
workflow (PyPI publish + GitHub Release).

## Type of change

- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix (N/A — no behavior change)
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]` (entries moved to the dated `[2.7.0]` section)
- [x] Docs updated on `docs.humanbound.ai` (N/A — release chore)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- none -->