### PR TITLE
fix(tests): stop telemetry disable test from sending real events in CI

### DIFF
--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -48,6 +48,8 @@ def _isolate(monkeypatch, tmp_path):
     and reset cached state on both consent and client modules."""
     for v in _ENV_VARS_TO_STRIP:
         monkeypatch.delenv(v, raising=False)
+    # Dead port: an unmocked send must never reach the real PostHog host.
+    monkeypatch.setenv("HB_POSTHOG_HOST", "http://127.0.0.1:9")
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     # Test suite runs from source; force non-editable so telemetry isn't auto-disabled.
@@ -440,7 +442,8 @@ def _prime_consent_for_clirunner():
     consent.is_enabled()
 
 
-def test_telemetry_disable_sets_opt_out_flag_and_confirms(tmp_path):
+def test_telemetry_disable_sets_opt_out_flag_and_confirms(tmp_path, mock_posthog):
+    # mock_posthog looks unused but intercepts the real telemetry_disabled send.
     _prime_consent_for_clirunner()
     runner = CliRunner()
     result = runner.invoke(telemetry_group, ["disable"])


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Stops the unit test suite from sending real `telemetry_disabled` events to
production PostHog on every CI run.

The pre-existing disable test invoked `hb telemetry disable` without mocking
the PostHog SDK. That was harmless until #81, which made the command fire a
final `telemetry_disabled` event — and the suite's autouse fixture strips the
CI env vars (and fakes a TTY / non-editable install), so the consent guards
that would normally suppress sends in CI are bypassed inside tests. Each CI
run (×3 Python matrix jobs) sent a phantom `reason: command` opt-out event
with the production key.

Two changes in `tests/unit/test_telemetry.py`:

- The disable test now takes the `mock_posthog` fixture, intercepting the send.
- Safety net: the autouse `_isolate` fixture points `HB_POSTHOG_HOST` at a
  dead local port (`127.0.0.1:9`), so any future unmocked send can never
  reach the real host — verified by running the full suite against a fake
  local PostHog server (old code: event arrives; fixed code: zero requests).

Test-only change — nothing shipped in the package is affected, so no
CHANGELOG entry and no release needed.

## Type of change

- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix (the change is itself in the tests)
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]` (N/A — test-only, not user-visible)
- [x] Docs updated on `docs.humanbound.ai` (N/A)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- follow-up to #81 -->
