### PR TITLE
fix(engine): stop empty-string config values from crashing the run (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Empty string values in a bot config no longer crash the run** (#64). An
+  empty `headers` or `payload` value (e.g. an optional header left blank) hit an
+  unguarded `item[0]` first-character check in the placeholder parser and raised
+  a raw `IndexError: string index out of range`. Empty strings are not
+  placeholders, so they now pass through unchanged like any other literal value.
+
 ## [2.7.0] — 2026-07-22
 
 ### Added

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -234,11 +234,11 @@ class Bot(ResponseExtractor):
                         )
                 return conversation_map_to_openai, False
 
-            if item[0] == "$":
+            if item.startswith("$"):
                 key = item[1:]
                 return (base_payload[key] if len(key) and key in base_payload else None), False
 
-            if item[0] == "\\":
+            if item.startswith("\\"):
                 return item[1:], False
 
         # fallback - return the item as is (probably a string without any placeholders or other base type)

--- a/tests/unit/test_engine_bot.py
+++ b/tests/unit/test_engine_bot.py
@@ -163,6 +163,29 @@ def test_parse_payload_passes_through_plain_string(bot):
     assert found is False
 
 
+def test_parse_payload_passes_through_empty_string(bot):
+    # An empty string is not a placeholder — it must pass through unchanged
+    # rather than crashing on the item[0] prefix check.
+    out, found = bot._Bot__parse_payload_item("", {}, u_prompt="ignored")
+    assert out == ""
+    assert found is False
+
+
+def test_prepare_headers_allows_empty_value(bot):
+    # Empty header values (e.g. an optional meta header left blank) must not crash.
+    out = bot._Bot__prepare_headers({"x-optional-meta": ""}, {})
+    assert out["x-optional-meta"] == ""
+
+
+def test_parse_payload_passes_through_non_string_scalars(bot):
+    # None / numbers / booleans aren't placeholders — they fall through the
+    # dict/list/str checks and are returned unchanged (the "other base type" path).
+    for value in [None, 0, 42, 3.14, True]:
+        out, found = bot._Bot__parse_payload_item(value, {})
+        assert out is value
+        assert found is False
+
+
 # ────────────────────────────────────────────────────────────────
 # __prepare_endpoint — path templating
 # ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

An empty string in a `chat_completion` `headers` or `payload` value hit an
unguarded `item[0]` first-character check in `__parse_payload_item` and raised
`IndexError: string index out of range`, aborting the whole run. Empty strings
are not placeholders, so the `$`/`\` prefix checks now use `str.startswith` —
empty input falls through to the pass-through fallback and is returned unchanged,
matching the documented "sent as-is after placeholder substitution" contract.

Behavior change to note: a config with an empty value used to crash the run;
it now runs and sends that empty value to the agent (the intended behavior).

Added regression tests for the empty string (direct call + empty header via
`__prepare_headers`) and a guardrail test pinning non-string scalars
(`None`/int/float/bool) through the fallback path. Full unit suite: 1000 passed.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — N/A, docs already state values are "sent as-is"; no valid-values table contradicts empty strings
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Closes #64