### PR TITLE
docs: note the Ollama air-gap provider needs the [engine] extra (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a raw `IndexError: string index out of range`. Empty strings are not
   placeholders, so they now pass through unchanged like any other literal value.
 
+### Documentation
+- **Clarify that the Ollama "air-gap" provider requires the `[engine]` extra.**
+  The README and docs showed the Ollama path under a plain
+  `pip install humanbound`, but the provider imports the `openai` SDK that ships
+  only in `[engine]`, so `HB_PROVIDER=ollama` failed with
+  `ModuleNotFoundError: No module named 'openai'` on a core install. The install
+  snippets now use `humanbound[engine]` for the air-gap path.
+
 ## [2.7.0] — 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ so the same run that finds a hole also patches it.
 
 ```bash
 pip install humanbound                       # CLI + SDK, core deps
-pip install humanbound[engine]               # + OpenAI / Anthropic / Gemini providers
+pip install humanbound[engine]               # + OpenAI / Anthropic / Gemini / Ollama providers
 pip install humanbound[firewall]             # + humanbound-firewall runtime
 pip install humanbound[engine,firewall]      # everything
 ```
@@ -71,9 +71,10 @@ hb logs                            # full multi-turn conversation logs
 hb report -o report.html           # HTML report
 ```
 
-Full air-gap with [Ollama](https://ollama.com) — zero external API calls:
+Full air-gap with [Ollama](https://ollama.com) — zero external API calls (requires the `[engine]` extra):
 
 ```bash
+pip install humanbound[engine]
 export HB_PROVIDER=ollama
 export HB_MODEL=llama3.1:8b
 hb test --endpoint ./bot-config.json --scope ./scope.yaml --wait

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -54,7 +54,7 @@ hb --help
 
 | Extra | Install | What it adds |
 |---|---|---|
-| `engine` | `pip install "humanbound[engine]"` | Local testing engine (OpenAI, Anthropic, Google SDKs) |
+| `engine` | `pip install "humanbound[engine]"` | Local testing engine (OpenAI, Anthropic, Google SDKs, Ollama) |
 | `firewall` | `pip install "humanbound[firewall]"` | Firewall training (humanbound-firewall, scikit-learn, torch) |
 | `mcp` | `pip install "humanbound[mcp]"` | MCP server for AI coding assistants |
 

--- a/docs/docs/local-engine/index.md
+++ b/docs/docs/local-engine/index.md
@@ -47,7 +47,7 @@ hb test --endpoint ./config.json --scope ./scope.json --wait
 
 ```bash
 # Install
-pip install humanbound
+pip install "humanbound[engine]"
 
 # Configure LLM provider
 export HB_PROVIDER=openai

--- a/docs/docs/local-engine/provider-config.md
+++ b/docs/docs/local-engine/provider-config.md
@@ -80,6 +80,9 @@ export HB_ENDPOINT="https://your-resource.openai.azure.com/openai/deployments/yo
 For zero external network calls — everything runs locally:
 
 ```bash
+# Install
+pip install "humanbound[engine]"
+
 # Start ollama
 ollama serve
 ollama pull llama3.1:8b


### PR DESCRIPTION
## Summary

The README and docs presented the Ollama "air-gap" path under a plain
`pip install humanbound`, but the provider imports the `openai` SDK that
ships only in the `[engine]` extra — so `HB_PROVIDER=ollama` failed with
`ModuleNotFoundError: No module named 'openai'` on a core install.

Point the air-gap install snippets at `humanbound[engine]`, list Ollama
under what `[engine]` provides, and add a CHANGELOG entry. No code change —
the provider works as-is once `[engine]` is installed.

## Type of change

- [x] Documentation only

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix — N/A (docs only)
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally — N/A (no code changed)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #52
