### PR TITLE
fix(test): correct --quick help to match behavior (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`--quick` help now matches its behavior** (#72). The flag advertised "top 4
+  OWASP categories, ~5 minutes" but only selected the `unit` testing level —
+  already the default — with no category filtering anywhere, so every scan ran
+  all categories. The help now reads "Shortcut for --testing-level unit"; as a
+  bonus, an explicit `--testing-level` combined with `--quick` (e.g.
+  `-l system --quick`) is no longer downgraded to `unit`.
 - **Empty string values in a bot config no longer crash the run** (#64). An
   empty `headers` or `payload` value (e.g. an optional header left blank) hit an
   unguarded `item[0]` first-character check in the placeholder parser and raised

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -257,7 +257,7 @@ def _fire_test_complete(
     "-q",
     is_flag=True,
     default=False,
-    help="Quick scan: top 4 OWASP categories, ~5 minutes",
+    help="Shortcut for --testing-level unit (fastest scan)",
 )
 @click.option(
     "--no-auto-start",
@@ -363,12 +363,19 @@ def test_command(
     # Resolve shorthand flags — explicit --testing-level / --test-category win
     if category and test_category == DEFAULT_TEST_CATEGORY:
         test_category = category
+    # --quick/--deep/--full select a testing level (first match wins), applied
+    # only when the user didn't set --testing-level explicitly.
     if quick:
-        testing_level = "unit"  # quick uses unit depth but fewer categories
-    elif deep and testing_level == "unit":
-        testing_level = "system"
-    elif full and testing_level == "unit":
-        testing_level = "acceptance"
+        shortcut_level = "unit"
+    elif deep:
+        shortcut_level = "system"
+    elif full:
+        shortcut_level = "acceptance"
+    else:
+        shortcut_level = None
+
+    if shortcut_level and testing_level == "unit":
+        testing_level = shortcut_level
 
     # Convert language code to full name if needed (e.g. "en" -> "english")
     lang = LANG_CODE_MAP.get(lang.lower(), lang)

--- a/tests/unit/test_test_cmd.py
+++ b/tests/unit/test_test_cmd.py
@@ -85,6 +85,43 @@ class TestHappyPath:
         assert _started_config(r).testing_level == "acceptance"
 
     @patch(RUNNER_PATCH)
+    def test_quick_flag_keeps_unit_level(self, mock_get_runner):
+        client = _make_client()
+        r = platform_runner(client)
+        mock_get_runner.return_value = r
+
+        result = runner.invoke(cli, ["test", "--quick"])
+
+        assert_exit_ok(result)
+        assert _started_config(r).testing_level == "unit"
+
+    @patch(RUNNER_PATCH)
+    def test_quick_does_not_downgrade_explicit_level(self, mock_get_runner):
+        """--quick maps to the default unit depth; an explicit --testing-level
+        must win rather than being silently downgraded to unit."""
+        client = _make_client()
+        r = platform_runner(client)
+        mock_get_runner.return_value = r
+
+        result = runner.invoke(cli, ["test", "--testing-level", "system", "--quick"])
+
+        assert_exit_ok(result)
+        assert _started_config(r).testing_level == "system"
+
+    @patch(RUNNER_PATCH)
+    def test_conflicting_depth_flags_quick_wins(self, mock_get_runner):
+        """Depth shortcuts resolve first-match-wins (quick > deep > full), so
+        combining all three deterministically yields the quick/unit level."""
+        client = _make_client()
+        r = platform_runner(client)
+        mock_get_runner.return_value = r
+
+        result = runner.invoke(cli, ["test", "--quick", "--deep", "--full"])
+
+        assert_exit_ok(result)
+        assert _started_config(r).testing_level == "unit"
+
+    @patch(RUNNER_PATCH)
     def test_no_auto_start(self, mock_get_runner):
         client = _make_client()
         r = platform_runner(client)


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

`--quick` advertised "top 4 OWASP categories, ~5 minutes" in its help text, but
the flag only set the testing level to `unit` — already the default — and no
category filtering exists anywhere in the run, so every scan ran all categories
regardless (23 for `owasp_agentic`). Both the category claim and the time
estimate were unreachable.

This corrects the flag to match reality rather than adding a feature:

- Help text is now **"Shortcut for --testing-level unit (fastest scan)"** — no
  false category/time claims.
- The depth shortcuts (`--quick` / `--deep` / `--full`) are resolved so an
  explicit `--testing-level` always wins. Previously `-l system --quick` was
  silently downgraded to `unit`; it now stays `system`, consistent with how
  `--deep`/`--full` already behaved.

Note: this fixes the *advertising*, not the runtime — `--quick` still runs at
`unit` depth. A genuinely narrowed "fast subset" mode would be a separate
enhancement (needs category-subset plumbing + a decision on which categories
count as the quick set).

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — n/a: the false claim lived only in the CLI `--help` string; no docs-site page documented `--quick`'s behavior (swept `docs/**`)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #72