### PR TITLE
fix(engine): keep completed conversations when a local run is interru…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Interrupting a local run no longer discards completed conversations**
+  (#75, reported by @guillaume-flambard). Local runs buffered finished
+  conversations and delivered them to the results writer only in batches, and
+  the batch was dropped once the run was cancelled — so `Ctrl+C` could leave
+  `hb posture` and `hb logs` with nothing despite a long run. Local runs now
+  flush every conversation as it is judged and still deliver whatever finished
+  when a run is interrupted, so completed work always reaches disk. Batched
+  (platform) log delivery is unchanged.
 - **`--quick` help now matches its behavior** (#72). The flag advertised "top 4
   OWASP categories, ~5 minutes" but only selected the `unit` testing level —
   already the default — with no category filtering anywhere, so every scan ran
@@ -21,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placeholders, so they now pass through unchanged like any other literal value.
 
 ### Documentation
-- **Clarify that the Ollama "air-gap" provider requires the `[engine]` extra.**
-  The README and docs showed the Ollama path under a plain
+- **Clarify that the Ollama "air-gap" provider requires the `[engine]` extra**
+  (#52). The README and docs showed the Ollama path under a plain
   `pip install humanbound`, but the provider imports the `openai` SDK that ships
   only in `[engine]`, so `HB_PROVIDER=ollama` failed with
   `ModuleNotFoundError: No module named 'openai'` on a core install. The install

--- a/humanbound_cli/engine/callbacks.py
+++ b/humanbound_cli/engine/callbacks.py
@@ -36,3 +36,26 @@ class EngineCallbacks:
 
     max_workers: int = 0
     """Override max thread workers. 0 = use default. 1 = single-threaded (debug mode)."""
+
+    flush_every_log: bool = False
+    """Flush each completed conversation to on_logs immediately, even after
+    termination. Set by in-process runners so an interrupt keeps finished work."""
+
+    def should_flush_every(self) -> bool:
+        """Flush per conversation instead of buffering (local sinks, debug runs)."""
+        return self.flush_every_log or self.max_workers == 1
+
+    def deliver_logs(self, logs: list) -> None:
+        """Hand completed logs to on_logs. Cancellation stops new work, not
+        delivery of finished work; batched sinks still suppress post-cancel."""
+        if not logs:
+            return
+        if self.is_terminated() and not self.flush_every_log:
+            return
+        self.on_logs(list(logs))
+
+
+def log_buffer_len(callbacks: EngineCallbacks | None, default: int) -> int:
+    """Orchestrator log-batching size: 0 (flush every log) when the sink asks
+    for it, else the orchestrator's default."""
+    return 0 if callbacks and callbacks.should_flush_every() else default

--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -42,6 +42,7 @@ class _LocalRun:
             is_terminated=self._terminated.is_set,
             on_error=lambda title, details: logger.warning(f"[{title}] {details}"),
             get_strategies=lambda pid: [],  # no cross-session FSLF locally
+            flush_every_log=True,
         )
 
         if self.config.debug:

--- a/humanbound_cli/engine/orchestrators/behavioral_qa/orchestrator.py
+++ b/humanbound_cli/engine/orchestrators/behavioral_qa/orchestrator.py
@@ -13,7 +13,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 
 from ...bot import Bot, Telemetry
-from ...callbacks import EngineCallbacks
+from ...callbacks import EngineCallbacks, log_buffer_len
 from ...schemas import LogsAnonymous, Status, Turn
 from .config import TestingConfiguration
 from .generator import Conversationer, Synthesizer
@@ -27,12 +27,8 @@ LOGS_BUFFER_LENGTH = 20
 
 
 def __do_register_logs(organisation_id, experiment, logs, callbacks=None):
-    if not len(logs):
-        return
-    if callbacks and callbacks.is_terminated():
-        return
     if callbacks:
-        callbacks.on_logs(list(logs))
+        callbacks.deliver_logs(logs)
 
 
 def __do_partial_generate(
@@ -74,7 +70,9 @@ def __do_thread_run(
             clientbot,
         )
         judge = Judge(model_provider, experiment["configuration"]["scope"], test_sub_category)
-        logs_buffer_len = min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH)
+        logs_buffer_len = log_buffer_len(
+            callbacks, min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH)
+        )
 
         telemetry_client = None
         if telemetry_config:
@@ -135,7 +133,7 @@ def __do_thread_run(
                     )
                     if len(logs) > logs_buffer_len:
                         __do_register_logs(organisation_id, experiment, logs, callbacks=callbacks)
-                        logs_buffer_len = LOGS_BUFFER_LENGTH
+                        logs_buffer_len = log_buffer_len(callbacks, LOGS_BUFFER_LENGTH)
                         logs = []
 
                     time.sleep(2)

--- a/humanbound_cli/engine/orchestrators/owasp_agentic/orchestrator.py
+++ b/humanbound_cli/engine/orchestrators/owasp_agentic/orchestrator.py
@@ -12,7 +12,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 
 from ...bot import Bot, Telemetry
-from ...callbacks import EngineCallbacks
+from ...callbacks import EngineCallbacks, log_buffer_len
 from ...schemas import LogsAnonymous, Status
 from .config import TestingConfiguration
 from .generator import Conversationer, Synthesizer
@@ -144,7 +144,7 @@ async def __do_single_pipeline_run(
         )
         if len(logs) > logs_buffer_len:
             __do_register_logs(organisation_id, experiment, logs, callbacks=callbacks)
-            logs_buffer_len = LOGS_BUFFER_LENGTH
+            logs_buffer_len = log_buffer_len(callbacks, LOGS_BUFFER_LENGTH)
             logs = []
         time.sleep(2)
     except Exception as e:
@@ -183,15 +183,8 @@ def __do_register_logs(
     logs,
     callbacks=None,
 ):
-    if not len(logs):
-        return
-
-    if callbacks and callbacks.is_terminated():
-        return
-
-    # Emit logs via callback
     if callbacks:
-        callbacks.on_logs(list(logs))
+        callbacks.deliver_logs(logs)
 
 
 def __do_thread_run(
@@ -221,11 +214,9 @@ def __do_thread_run(
     ):
         e_id = experiment["id"]
         logs = []
-        # Debug mode: flush after every conversation (no buffering)
-        if callbacks and callbacks.max_workers == 1:
-            logs_buffer_len = 0
-        else:
-            logs_buffer_len = min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH)
+        logs_buffer_len = log_buffer_len(
+            callbacks, min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH)
+        )
 
         judge = Judge(
             model_provider,

--- a/humanbound_cli/engine/orchestrators/owasp_single_turn/orchestrator.py
+++ b/humanbound_cli/engine/orchestrators/owasp_single_turn/orchestrator.py
@@ -13,7 +13,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 
 from ...bot import Bot, Telemetry
-from ...callbacks import EngineCallbacks
+from ...callbacks import EngineCallbacks, log_buffer_len
 from ...schemas import LogsAnonymous, Status, Turn
 from .config import TestingConfiguration
 from .generator import Conversationer, Synthesizer
@@ -28,12 +28,8 @@ SINGLE_TURN_WORKER_COUNT = 5
 
 
 def __do_register_logs(organisation_id, experiment, logs, callbacks=None):
-    if not len(logs):
-        return
-    if callbacks and callbacks.is_terminated():
-        return
     if callbacks:
-        callbacks.on_logs(list(logs))
+        callbacks.deliver_logs(logs)
 
 
 def __do_partial_generate(
@@ -76,7 +72,7 @@ def __do_thread_run(
 
     logs = []
     logs_lock = threading.Lock()
-    logs_buffer_len = min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH)
+    logs_buffer_len = log_buffer_len(callbacks, min(INIT_LOGS_BUFFER_LENGTH, LOGS_BUFFER_LENGTH))
 
     def _process_prompt(idx, prompt):
         nonlocal logs, logs_buffer_len
@@ -127,7 +123,7 @@ def __do_thread_run(
                 if len(logs) > logs_buffer_len:
                     _to_flush = logs[:]
                     logs = []
-                    logs_buffer_len = LOGS_BUFFER_LENGTH
+                    logs_buffer_len = log_buffer_len(callbacks, LOGS_BUFFER_LENGTH)
                 else:
                     _to_flush = None
 

--- a/tests/unit/test_engine_interrupt.py
+++ b/tests/unit/test_engine_interrupt.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Interrupting a local run must keep completed conversations.
+
+Unit layer: the ``EngineCallbacks`` delivery contract and its wiring — every
+orchestrator routes logs through ``deliver_logs``, and the local runner opts
+into flush-every-log.
+
+Integration layer, sharing one deterministic harness (a worker genuinely stuck
+mid-conversation when the interrupt lands): a regression guard proving the old
+batched drop-on-cancel behaviour loses finished work, and the real ``hb test``
+command with the real ``LocalTestRunner`` thread and a genuine
+``KeyboardInterrupt`` in the wait loop, saving partial results to disk. Only
+the LLM/network leaves and the telemetry transport are mocked.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import threading
+import time as _time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from humanbound_cli.engine.callbacks import EngineCallbacks
+from humanbound_cli.engine.local_runner import _LocalRun
+from humanbound_cli.engine.runner import TestConfig as _TestConfig
+from humanbound_cli.main import cli
+
+ORCH = importlib.import_module("humanbound_cli.engine.orchestrators.owasp_agentic.orchestrator")
+
+ORCHESTRATOR_MODULES = [
+    "humanbound_cli.engine.orchestrators.owasp_agentic.orchestrator",
+    "humanbound_cli.engine.orchestrators.owasp_single_turn.orchestrator",
+    "humanbound_cli.engine.orchestrators.behavioral_qa.orchestrator",
+]
+
+TOTAL = 5  # conversations the run would produce
+STICK_AT = 3  # the Nth conversation blocks mid-flight when the interrupt lands
+
+
+# ── unit: delivery contract ───────────────────────────────────────────────
+
+
+def test_deliver_logs_drops_after_cancel_for_batched_sinks():
+    received: list = []
+    cb = EngineCallbacks(on_logs=received.extend, is_terminated=lambda: True, flush_every_log=False)
+    cb.deliver_logs([1, 2])
+    assert received == []
+
+
+def test_deliver_logs_delivers_after_cancel_for_local_sinks():
+    received: list = []
+    cb = EngineCallbacks(on_logs=received.append, is_terminated=lambda: True, flush_every_log=True)
+    buffer = [1, 2]
+    cb.deliver_logs(buffer)
+    buffer.append(3)
+    assert received == [[1, 2]]  # delivered, and as a copy
+    cb.deliver_logs([])
+    assert received == [[1, 2]]  # empty batch is a no-op
+
+
+def test_should_flush_every():
+    assert EngineCallbacks().should_flush_every() is False
+    assert EngineCallbacks(flush_every_log=True).should_flush_every() is True
+    assert EngineCallbacks(max_workers=1).should_flush_every() is True  # debug mode
+
+
+@pytest.mark.parametrize("module", ORCHESTRATOR_MODULES)
+def test_orchestrators_route_logs_through_deliver_logs(module):
+    register = getattr(importlib.import_module(module), "__do_register_logs")
+    received: list = []
+    cb = EngineCallbacks(on_logs=received.extend, is_terminated=lambda: True, flush_every_log=True)
+    register("org", {"id": "exp-1"}, [{"thread_id": "t0"}], callbacks=cb)
+    assert received == [{"thread_id": "t0"}]
+    register("org", {"id": "exp-1"}, [{"thread_id": "t1"}], callbacks=None)  # must not raise
+
+
+def test_local_runner_opts_into_flush_every():
+    cb = _LocalRun("exp-1", _TestConfig()).make_callbacks()
+    assert cb.flush_every_log is True
+    debug_cb = _LocalRun("exp-1", _TestConfig(debug=True)).make_callbacks()
+    assert debug_cb.max_workers == 1
+    assert debug_cb.should_flush_every() is True
+
+
+# ── integration harness ───────────────────────────────────────────────────
+
+
+class _Harness:
+    """Deterministic fakes: N-1 conversations complete, the Nth blocks until
+    released so the interrupt lands while a worker is genuinely mid-conversation.
+    """
+
+    def __init__(self):
+        self.completed = 0
+        self.lock = threading.Lock()
+        self.stuck = threading.Event()
+        self.release = threading.Event()
+
+    def conversationer_cls(harness):
+        class FakeConversationer:
+            number_of_iterations = 1
+
+            def __init__(self, *a, **k):
+                pass
+
+            async def chat(self, *a, **k):
+                with harness.lock:
+                    n = harness.completed + 1
+                if n == STICK_AT:
+                    harness.stuck.set()
+                    harness.release.wait(timeout=10)
+                    raise RuntimeError("interrupted mid-conversation")
+                with harness.lock:
+                    harness.completed += 1
+                return [{"u": f"attack-{n}", "a": f"response-{n}"}], f"tid-{n}", 0.01, None
+
+        return FakeConversationer
+
+
+class _FakeJudge:
+    def __init__(self, *a, **k):
+        pass
+
+    def evaluate(self, conversation, telemetry_data=None):
+        return {
+            "result": "pass",
+            "category": "",
+            "explanation": "ok",
+            "severity": 0,
+            "confidence": 90,
+        }
+
+
+_FAKE_CONFIG = {"data": {"cat1": {"attack_gen_template": [f"t{i}" for i in range(TOTAL)]}}}
+
+
+def test_old_batched_behavior_loses_completed_conversations():
+    """Regression guard: without flush_every_log, cancelling drops the buffered
+    conversations before they ever reach the sink."""
+    harness = _Harness()
+    sink: list = []
+    terminated = threading.Event()
+    cb = EngineCallbacks(
+        on_logs=sink.extend, is_terminated=terminated.is_set, flush_every_log=False
+    )
+    experiment = {
+        "id": "exp-e2e",
+        "project_id": "",
+        "configuration": {"scope": {}, "integration": {}, "context": ""},
+        "lang": "english",
+        "testing_level": "unit",
+    }
+
+    with (
+        patch.object(ORCH, "Conversationer", harness.conversationer_cls()),
+        patch.object(ORCH, "Judge", _FakeJudge),
+        patch.object(ORCH, "Bot", lambda *a, **k: object()),
+        patch.object(ORCH.TestingConfiguration, "config", _FAKE_CONFIG),
+        patch.object(ORCH.time, "sleep", lambda *a, **k: None),
+    ):
+        thread = threading.Thread(
+            target=ORCH.orchestrator_run,
+            args=("org", {"name": "fake"}, experiment, {"cat1": []}, None, cb),
+            daemon=True,
+        )
+        thread.start()
+        try:
+            assert harness.stuck.wait(timeout=5), "worker never reached the stuck conversation"
+            terminated.set()  # the interrupt
+        finally:
+            harness.release.set()
+            thread.join(timeout=5)
+
+    assert harness.completed == STICK_AT - 1
+    assert sink == []  # completed conversations were dropped — the original bug
+
+
+def test_cli_ctrl_c_saves_partial_results(tmp_path, monkeypatch):
+    """Real `hb test --local --wait` + real KeyboardInterrupt in the wait loop:
+    the handler in commands/test.py must save completed conversations to disk."""
+    from humanbound_cli.engine.local_runner import LocalTestRunner
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HUMANBOUND_DEV", "1")  # telemetry: dev installs never send
+    monkeypatch.setenv("HOME", str(tmp_path))  # isolate ~/.humanbound
+
+    (tmp_path / "bot-config.json").write_text(
+        json.dumps(
+            {
+                "streaming": None,
+                "chat_completion": {
+                    "endpoint": "http://127.0.0.1:9/chat",
+                    "headers": {},
+                    "payload": {"content": "$PROMPT"},
+                },
+            }
+        )
+    )
+
+    harness = _Harness()
+    real_sleep = _time.sleep
+    main_thread = threading.main_thread()
+
+    def fake_sleep(seconds=0):
+        # Main thread = the wait loop in test.py. Once a worker is stuck
+        # mid-conversation, the next poll-sleep becomes the user's Ctrl+C.
+        if threading.current_thread() is main_thread and harness.stuck.is_set():
+            threading.Timer(0.2, harness.release.set).start()
+            raise KeyboardInterrupt
+        real_sleep(0)
+
+    with (
+        patch("humanbound_cli.commands.test.get_runner", return_value=LocalTestRunner()),
+        patch(
+            "humanbound_cli.engine.local_runner._resolve_provider",
+            return_value={"name": "fake", "integration": {}},
+        ),
+        patch("humanbound_cli.engine.llm.get_llm_pinger", return_value=None),
+        patch("humanbound_cli.engine.scope.resolve", return_value={}),
+        patch.object(ORCH, "orchestrator_generate", return_value={"cat1": []}),
+        patch.object(ORCH, "Conversationer", harness.conversationer_cls()),
+        patch.object(ORCH, "Judge", _FakeJudge),
+        patch.object(ORCH, "Bot", lambda *a, **k: object()),
+        patch.object(ORCH.TestingConfiguration, "config", _FAKE_CONFIG),
+        patch("time.sleep", side_effect=fake_sleep),
+        patch("os._exit", side_effect=SystemExit(0)),  # handler ends in os._exit(0)
+        patch("humanbound_cli.telemetry.client._posthog", MagicMock()),
+    ):
+        result = CliRunner().invoke(
+            cli, ["test", "--endpoint", "bot-config.json", "--local", "--wait"]
+        )
+
+    assert "Interrupted. Stopping test" in result.output
+    assert "Partial results" in result.output
+
+    exp_dirs = list((tmp_path / ".humanbound" / "results").iterdir())
+    assert len(exp_dirs) == 1
+    entries = [
+        json.loads(line) for line in (exp_dirs[0] / "logs.jsonl").read_text().strip().splitlines()
+    ]
+    passed = [e for e in entries if e.get("result") == "pass"]
+    assert harness.completed == STICK_AT - 1
+    assert len(passed) == harness.completed, (
+        f"completed {harness.completed} conversations but only {len(passed)} on disk"
+    )
+    assert (exp_dirs[0] / "meta.json").exists()


### PR DESCRIPTION
## Summary

Interrupting a local `hb test` run discarded all results, including conversations
that had already completed and been judged (#75). The CLI prints "Ctrl+C will stop
the test", and `commands/test.py` even has a partial-save handler — but it never
had anything to save: completed conversations were buffered inside the orchestrators
and only handed to the results sink in batches (20–70 conversations), and
`__do_register_logs` dropped the buffered batch once the run was terminated. After
a long run, `hb posture` and `hb logs` reported "No local test results found".

This PR makes local runs flush every conversation to the sink the moment it is
judged, and still deliver whatever finished when a run is cancelled:

- `EngineCallbacks` gains `flush_every_log`, `should_flush_every()`, and
  `deliver_logs()` — the delivery guard, previously triplicated across the three
  orchestrators, now lives in one place. Batched (platform/SDK) sinks keep the
  existing suppress-after-cancel behavior.
- `LocalTestRunner` opts into `flush_every_log` (its sink is an in-memory list, so
  batching bought nothing and cost completed work on interrupt).
- All three orchestrators route log delivery through `deliver_logs` and size their
  buffers via a shared `log_buffer_len` helper. This also fixes a latent debug-mode
  bug where the per-conversation flush was reset to a 20-conversation buffer after
  the first flush.

Verified at every layer: unit tests for the delivery contract, an integration
regression guard reproducing the original drop, a CLI-level test driving the real
`hb test` command with a real `KeyboardInterrupt` in the wait loop, and manual
runs in an offline sandbox with a real SIGINT — partial results save, and
`hb posture` / `hb logs` work on them.

Reported by @guillaume-flambard — thanks for the precise trace.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (not applicable — no docs page describes interrupt behavior)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #75
