### PR TITLE
security(engine): don't follow redirects on LLM provider API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a raw `IndexError: string index out of range`. Empty strings are not
   placeholders, so they now pass through unchanged like any other literal value.
 
+### Security
+- **LLM provider API calls no longer follow HTTP redirects**, so credential
+  headers can't be re-sent to a redirected host.
+
 ### Documentation
 - **Clarify that the Ollama "air-gap" provider requires the `[engine]` extra**
   (#52). The README and docs showed the Ollama path under a plain

--- a/humanbound_cli/engine/llm/azureopenai.py
+++ b/humanbound_cli/engine/llm/azureopenai.py
@@ -131,6 +131,7 @@ class LLMPinger:
                 headers=headers,
                 json=payload,
                 timeout=LLM_PING_TIMEOUT,
+                allow_redirects=False,
             )
 
             # handle response
@@ -203,6 +204,7 @@ class EmbeddingsExtractor:
             },
             json={"input": data},
             timeout=90,  # 90 second timeout (cold start: model download + load + inference)
+            allow_redirects=False,
         )
         if response.status_code != 200:
             raise Exception(f"Embeddings API error {response.status_code}: {response.text[:500]}")

--- a/humanbound_cli/engine/llm/openai.py
+++ b/humanbound_cli/engine/llm/openai.py
@@ -86,6 +86,7 @@ class LLMPinger:
                 "temperature": temperature,
             },
             timeout=LLM_PING_TIMEOUT,
+            allow_redirects=False,
         )
 
     def ping(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-timeout>=2.3",
-    "ruff>=0.6",
+    "ruff==0.15.12",
     "mypy>=1.11",
     "build>=1.2",
     "twine>=5.0",

--- a/tests/unit/test_llm_pinger.py
+++ b/tests/unit/test_llm_pinger.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024-2026 Humanbound
 """Tests for the LLM pinger factory: provider name resolution and aliases."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from humanbound_cli.engine.llm import (
@@ -64,3 +66,58 @@ class TestAliasReachesClaudePinger:
         pytest.importorskip("anthropic")  # SDK ships in the [engine] extra
         pinger = get_llm_pinger({"name": "anthropic", "integration": {"api_key": "x"}})
         assert type(pinger).__module__ == "humanbound_cli.engine.llm.claude"
+
+
+class TestPingersDisableRedirects:
+    """Credential-bearing ``requests.post`` calls must not follow redirects.
+
+    ``requests`` strips only ``Authorization`` on a cross-host redirect, not custom
+    headers such as ``Api-Key`` / ``x-hb-key-internal``, so a redirecting endpoint
+    could re-send the provider key to another host. Mirrors the bot HTTP/SSE
+    reject-redirect behavior (see ``test_engine_bot.py``).
+    """
+
+    @staticmethod
+    def _resp(payload):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = payload
+        return r
+
+    def test_azure_pinger_disables_redirects(self):
+        pytest.importorskip("openai")  # azureopenai imports the openai SDK ([engine] extra)
+        from humanbound_cli.engine.llm.azureopenai import LLMPinger
+
+        provider = {
+            "integration": {
+                "api_key": "k",
+                "model": "gpt-4o",
+                "endpoint": "https://user.example/chat",
+            }
+        }
+        completion = {"choices": [{"message": {"content": "hi"}}], "usage": {}}
+        with patch("humanbound_cli.engine.llm.azureopenai.requests.post") as post:
+            post.return_value = self._resp(completion)
+            LLMPinger(provider).ping("sys", "usr")
+        assert post.call_args.kwargs.get("allow_redirects") is False
+
+    def test_embeddings_extractor_disables_redirects(self):
+        pytest.importorskip("openai")
+        from humanbound_cli.engine.llm.azureopenai import EmbeddingsExtractor
+
+        provider = {"integration": {"api_key": "k", "endpoint": "https://user.example/embed"}}
+        with patch("humanbound_cli.engine.llm.azureopenai.requests.post") as post:
+            post.return_value = self._resp({"data": [{"embedding": [0.1, 0.2]}]})
+            EmbeddingsExtractor(provider).encode(["a"])
+        assert post.call_args.kwargs.get("allow_redirects") is False
+
+    def test_openai_pinger_disables_redirects(self):
+        pytest.importorskip("openai")
+        from humanbound_cli.engine.llm.openai import LLMPinger
+
+        provider = {"integration": {"api_key": "k", "model": "gpt-4o"}}
+        completion = {"choices": [{"message": {"content": "hi"}}], "usage": {}}
+        with patch("humanbound_cli.engine.llm.openai.requests.post") as post:
+            post.return_value = self._resp(completion)
+            LLMPinger(provider).ping("sys", "usr")
+        assert post.call_args.kwargs.get("allow_redirects") is False


### PR DESCRIPTION
## Summary

Disables HTTP redirect-following on the LLM-provider API calls that send the
provider key in a custom header.

The Azure `LLMPinger` POSTs the provider key in an `Api-Key` header to a
user-configured endpoint. `requests` strips only `Authorization` on a cross-host
redirect, not custom headers, so a redirecting or compromised endpoint could
re-send the key to another host. Pass `allow_redirects=False` so a redirect
surfaces as an error instead, matching the reject-redirect behavior already
enforced on the bot HTTP/SSE paths (`_raise_if_redirect`).

Applied uniformly to the OpenAI pinger and embeddings extractor for the same
pattern. Adds `TestPingersDisableRedirects` to `test_llm_pinger.py`.

**Behavioral note:** an endpoint that legitimately returns a redirect will now
error instead of being followed (configure the final URL directly). Direct API
endpoints, which return `200`, are unaffected.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — N/A, internal hardening
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)
