### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ Deploy the output with
 your agent is protected against exactly the attacks it just failed. No other
 open-source tool closes this loop.
 
+## Show you tested with Humanbound
+
+Ran `hb test` against your agent? Add this badge to your README:
+
+[![Tested with Humanbound](https://img.shields.io/badge/tested%20with-humanbound-FD9506?style=flat-square)](https://github.com/humanbound/humanbound)
+
+`[![Tested with Humanbound](https://img.shields.io/badge/tested%20with-humanbound-FD9506?style=flat-square)](https://github.com/humanbound/humanbound)`
+
 ## Python SDK
 
 ```python


### PR DESCRIPTION
Add "Tested with Humanbound" badge section to README

Adds a new README section for anyone who's run hb test against their agent and wants to show it in their own project's README.

What changed
One new section, placed after "From test results to guardrails" and before "Python SDK." No code changes, README only.

What it contains
A static badge (shields.io, matching the existing badge style: flat-square, FD9506) plus the raw markdown snippet in a code block so it's copyable.

Why
Gives adopters an easy way to signal they've tested their agent with Humanbound. Every project that adds it is also a backlink to this repo, so it's a small assist for discoverability alongside the badge itself.

<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

<!-- What does this change do and why? -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [ ] Build / tooling / CI

## Checklist

- [ ] Tests added for new behavior / regression covered for a bug fix
- [ ] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [ ] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
