### PR TITLE
feat(docker): official CLI image published to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build context hygiene — shared by all docker/Dockerfile* variants.
+.git
+.github
+.venv
+venv
+tests
+docs
+assets
+dist
+build
+*.egg-info
+__pycache__
+**/__pycache__
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.humanbound
+docker
+*.md
+!README.md
+.pypirc
+relay
+.claude
+.superpowers
+.env
+*.env

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: Docker
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - ".dockerignore"
+      - "pyproject.toml"
+      - ".github/workflows/docker.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-smoke:
+    name: Build image + smoke test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build (amd64, no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          load: true
+          tags: humanbound:smoke
+      - name: Smoke test
+        run: |
+          docker run --rm humanbound:smoke --version
+          docker run --rm humanbound:smoke test --help
+          docker run --rm --entrypoint python humanbound:smoke -c "import openai, anthropic, google.generativeai"
+          test "$(docker run --rm --entrypoint id humanbound:smoke -u)" = "1000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,41 @@ jobs:
           files: |
             dist/*
           generate_release_notes: false
+
+  publish-docker:
+    name: Publish image to GHCR
+    runs-on: ubuntu-latest
+    # Independent of the PyPI jobs: the image is built from the tagged
+    # source, not the published package.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata (tags + OCI labels)
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/humanbound/humanbound
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Build + push (amd64, arm64)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Official Docker image** — `ghcr.io/humanbound/humanbound`, published to
+  GitHub Container Registry on every release (multi-arch `linux/amd64` +
+  `linux/arm64`; tags `:X.Y.Z`, `:X.Y`, `:X`, `:latest`). Runs the CLI with no
+  Python install: mount your project at `/workspace`, run `hb` commands as
+  usual, and results persist to the host through the mount. Ships the
+  `[engine]` extra for local-mode testing. Built from source in CI with
+  provenance attestation and SBOM; PRs touching the Docker files get an
+  automatic build + smoke test. See the new
+  [Docker integration docs](https://docs.humanbound.ai/integrations/docker/).
+
 ### Fixed
 - **Interrupting a local run no longer discards completed conversations**
   (#75, reported by @guillaume-flambard). Local runs buffered finished

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ pip install humanbound[firewall]             # + humanbound-firewall runtime
 pip install humanbound[engine,firewall]      # everything
 ```
 
+### Docker
+
+Run the CLI from the official image ([docs](https://docs.humanbound.ai/integrations/docker/)):
+
+```bash
+docker run --rm -v "$PWD":/workspace \
+  -e HB_PROVIDER=openai -e HB_API_KEY=$OPENAI_API_KEY -e HB_MODEL=gpt-4o-mini \
+  ghcr.io/humanbound/humanbound:2 test --endpoint ./bot-config.json --wait
+```
+
 ### CLI usage
 
 ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+# Build from source: wheel in stage 1, slim runtime in stage 2.
+# Build from the REPO ROOT:  docker build -f docker/Dockerfile -t humanbound:dev .
+
+FROM python:3.12-slim AS builder
+WORKDIR /src
+COPY . .
+RUN pip install --no-cache-dir build \
+    && python -m build --wheel --outdir /wheels
+
+FROM python:3.12-slim
+LABEL org.opencontainers.image.source="https://github.com/humanbound/humanbound" \
+    org.opencontainers.image.description="Humanbound CLI - open-source adversarial testing engine for AI agents" \
+    org.opencontainers.image.licenses="Apache-2.0"
+ENV PYTHONUNBUFFERED=1 \
+    HOME=/home/hb
+RUN useradd --create-home --uid 1000 hb \
+    && mkdir -p /workspace \
+    && chown hb:hb /workspace
+COPY --from=builder /wheels /tmp/wheels
+# discovery documents: ~99MB of unused Google API catalogs (fetched on demand if needed)
+RUN pip install --no-cache-dir "$(ls /tmp/wheels/humanbound-*.whl)[engine]" \
+    && rm -rf /tmp/wheels \
+    /usr/local/lib/python3.12/site-packages/googleapiclient/discovery_cache/documents \
+    && pip uninstall -y pip
+USER hb
+WORKDIR /workspace
+ENTRYPOINT ["hb"]
+CMD ["--help"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,41 @@
+# Docker images
+
+Contributor notes for the container images. **User-facing docs live at
+[docs/docs/integrations/docker.md](../docs/docs/integrations/docker.md)**
+(published at https://docs.humanbound.ai).
+
+## Files
+
+| File | Image | Extras |
+|---|---|---|
+| `Dockerfile` | `ghcr.io/humanbound/humanbound` — the default CLI image | `[engine]` |
+
+Future variants follow the `Dockerfile.<variant>` convention
+(e.g. `Dockerfile.mcp`, `Dockerfile.firewall`).
+
+## Building locally
+
+The build context is the **repo root** (the wheel is built from source in
+stage 1), so always pass `-f`:
+
+```bash
+docker build -f docker/Dockerfile -t humanbound:dev .
+```
+
+The single `.dockerignore` lives at the repo root and is shared by all
+variants.
+
+## Smoke test
+
+```bash
+docker run --rm humanbound:dev --version
+docker run --rm --entrypoint python humanbound:dev -c "import openai, anthropic, google.generativeai"
+```
+
+## CI
+
+- PRs to `main` touching `docker/**`, `.dockerignore`, `pyproject.toml`, or
+  the workflow file itself trigger a build + smoke test
+  (`.github/workflows/docker.yml`).
+- Version tags (`v*`) publish multi-arch (amd64 + arm64) images to GHCR with
+  `:X.Y.Z`, `:X.Y`, `:X`, and `:latest` tags (`.github/workflows/release.yml`).

--- a/docs/docs/integrations/cicd.md
+++ b/docs/docs/integrations/cicd.md
@@ -11,6 +11,8 @@ keywords:
   - automated security tests
   - pipeline integration
   - --wait CI flag
+  - GitLab CI Docker
+  - CircleCI Docker
 faq:
   - q: Is there a GitHub Action for Humanbound?
     a: "Yes. The official [`humanbound/actions`](https://github.com/marketplace/actions/humanbound-ai-agent-security-testing) Action wraps `hb test` — it installs the CLI, runs the scan, gates the build with `fail-on`, and uploads findings to the GitHub Security tab as SARIF. Reference it as `uses: humanbound/actions@v1`."
@@ -125,5 +127,38 @@ The same pattern works on Jenkins, CircleCI, and others — install `humanbound[
 !!! tip
     Always use `--wait` in CI/CD so the test completes before the job finishes (the GitHub
     Action does this for you). Use `--fail-on` to enforce a security quality gate.
+
+## Other CI systems (via the Docker image)
+
+These snippets run the official [`ghcr.io/humanbound/humanbound`](docker.md) image directly in
+local mode — no Python install needed on the runner. See the [Docker page](docker.md) for mount
+and networking details (workspace mounts, `host.docker.internal`, platform-auth mounts).
+
+### GitLab CI
+
+```yaml
+adversarial-test:
+  image:
+    name: ghcr.io/humanbound/humanbound:2
+    entrypoint: [""]
+  script:
+    - hb test --endpoint ./endpoint.json --wait --fail-on high
+  variables:
+    HB_PROVIDER: openai
+    HB_MODEL: gpt-4o-mini
+    HB_API_KEY: $OPENAI_API_KEY
+```
+
+### CircleCI
+
+```yaml
+jobs:
+  adversarial-test:
+    docker:
+      - image: ghcr.io/humanbound/humanbound:2
+    steps:
+      - checkout
+      - run: hb test --endpoint ./endpoint.json --wait --fail-on high
+```
 
 <!-- faq -->

--- a/docs/docs/integrations/docker.md
+++ b/docs/docs/integrations/docker.md
@@ -1,0 +1,128 @@
+---
+description: "Run the Humanbound CLI from the official Docker image — no Python install required. Covers the quickstart, file mounts, and platform auth; see CI/CD for pipeline examples."
+keywords:
+  - Docker image
+  - ghcr.io/humanbound/humanbound
+  - hb CLI Docker
+  - container security testing
+  - docker run hb test
+  - host.docker.internal
+  - Docker CI/CD
+---
+
+# Docker
+
+Run the `hb` CLI anywhere Docker runs — no Python required. The official
+image is published to GitHub Container Registry on every release:
+
+```bash
+docker pull ghcr.io/humanbound/humanbound
+```
+
+**Pin a tag in CI.** `:X.Y.Z`, `:X.Y`, and `:X` are published for every
+release; `:latest` is for interactive experimentation, not pipelines.
+Un-tagged and `:latest` always point at the newest release; `:2` tracks the
+newest `2.x.y` and is re-pointed with every release in that major line;
+`:2.7` and `:2.7.0` freeze to progressively narrower versions.
+
+## Quick start (local mode — no login)
+
+```bash
+docker run --rm \
+  -v "$PWD":/workspace \
+  -e HB_PROVIDER=openai -e HB_API_KEY=$OPENAI_API_KEY -e HB_MODEL=gpt-4o-mini \
+  ghcr.io/humanbound/humanbound \
+  test --endpoint ./endpoint.json --wait --fail-on high
+```
+
+- `--rm` — the container runs one command, exits with `hb`'s exit code
+  (`0` pass / `1` findings at or above `--fail-on` / `2` error), and removes
+  itself.
+- `-v "$PWD":/workspace` — mounts your project at the image's working directory.
+  Inputs are read through it and results are written back through it.
+
+## Two different keys
+
+| Variable | What it is |
+|---|---|
+| `HB_API_KEY` | Your **LLM provider** key (OpenAI, Anthropic, …) — powers the attacker/judge models in local mode |
+| `HUMANBOUND_API_KEY` | Your **Humanbound platform** project key — headless platform auth (coming soon) |
+
+## Files in, results out
+
+All file options (`--endpoint`, `--scope`, `--prompt`, `--context`,
+`--repo`) are read inside the container. The rule: **mount your project at
+`/workspace` and use relative paths** — `--scope ./scope.yaml` resolves to the
+mounted host file. Absolute host paths do not exist inside the container, and
+what happens next depends on the option: `--scope`, `--prompt`, and `--repo`
+fail fast with a "does not exist" error; `--endpoint` falls through to "must
+be a JSON string or path to a JSON file"; `--context` does neither — a
+nonexistent path is silently treated as the literal context string. Double
+check `--context` in particular, since a typo'd path won't error, it'll just
+send the wrong text to the judge.
+
+Results persist to `./.humanbound/results/exp-*/` on your host through the
+same mount. Reports too:
+
+```bash
+docker run --rm -v "$PWD":/workspace ghcr.io/humanbound/humanbound report -o ./report.html
+```
+
+Inline escape hatches (no files needed): `--endpoint` accepts a JSON string
+and `--context` accepts a plain string — useful for templating from CI
+secrets.
+
+**Two different `.humanbound` directories.** `<project>/.humanbound/results/`
+is written relative to your workdir and persists on the host through the
+`/workspace` mount above — that's the test results and reports. `~/.humanbound/`
+in the container's home directory is a separate thing entirely: platform
+credentials, config, and the telemetry identity. It only exists inside the
+container if you mount it yourself, as shown in [Platform commands](#platform-commands).
+
+## Reaching an agent on your host
+
+Inside a container, `localhost` is the container. If the agent under test
+runs on your machine:
+
+- **macOS / Windows:** use `http://host.docker.internal:<port>` in your
+  endpoint config.
+- **Linux:** add `--add-host=host.docker.internal:host-gateway` to
+  `docker run`, or use `--network host`.
+
+## Platform commands
+
+`hb status`, project-scoped `hb logs`, and platform-mode `hb test` need platform auth:
+
+- **Today:** log in on the host, then mount your credentials (read-write —
+  the CLI refreshes tokens):
+
+  ```bash
+  hb login   # on the host, once
+  docker run --rm -v ~/.humanbound:/home/hb/.humanbound \
+    ghcr.io/humanbound/humanbound status
+  ```
+
+- **Coming soon:** `-e HUMANBOUND_API_KEY=<project-key>` — headless project-key
+  auth, no browser involved.
+
+## Using the image in CI
+
+For ready-made GitLab and CircleCI snippets that run this image in
+your pipeline, see [CI/CD Integration](cicd.md#other-ci-systems-via-the-docker-image).
+
+## Notes
+
+- Linux bind-mount permissions: the container runs as uid 1000; add
+  `--user $(id -u):$(id -g)` if your uid differs and result files come out
+  root-owned or unwritable.
+- Telemetry follows the CLI's normal rules — auto-disabled when a CI
+  environment variable is set, and `-e HB_TELEMETRY_DISABLED=1` or
+  `-e DO_NOT_TRACK=1` always works. It's also auto-disabled whenever the
+  container has no TTY, which is every `docker run` without `-it` — including
+  all of the example commands on this page — so scripted and CI runs never
+  send anything. The fresh-machine caveat (a new anonymous ID and `install`
+  event per container) only applies to interactive `-it` runs without a
+  mounted `~/.humanbound`; mounting it as shown in Platform commands keeps the
+  telemetry identity stable.
+- Commands that open a browser (`hb login`, `hb docs`) don't work inside a
+  container — run them on the host.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - Agent Discovery: integrations/discovery.md
     - Telemetry (Whitebox): integrations/telemetry.md
     - CI/CD: integrations/cicd.md
+    - Docker: integrations/docker.md
     - SIEM: integrations/siem.md
     - MCP Server: integrations/mcp.md
   - 🧩 Plugins [Preview]:


### PR DESCRIPTION
## Summary

Official Docker image for the `hb` CLI: `ghcr.io/humanbound/humanbound`, published
to GHCR on every release (multi-arch `linux/amd64` + `linux/arm64`; tags
`:X.Y.Z` / `:X.Y` / `:X` / `:latest`).

- Multi-stage `docker/Dockerfile`: wheel built from source into
  `python:3.12-slim` with the `[engine]` extra; non-root uid 1000,
  `ENTRYPOINT ["hb"]`, `/workspace` as the single mount point (inputs in,
  `.humanbound/results/` out). 255 MB after dropping googleapiclient's unused
  discovery documents (~99 MB) and pip.
- CI: `docker.yml` builds + smoke-tests the image on PRs touching the Docker
  files; `release.yml` gains a `publish-docker` job (GHCR via the built-in
  `GITHUB_TOKEN`, provenance attestation + SBOM, all actions SHA-pinned,
  least-privilege permissions).
- Docs: new `integrations/docker` page (mount rule, `HB_API_KEY` vs
  `HUMANBOUND_API_KEY`, `host.docker.internal` callout, telemetry behavior in
  containers), GitLab/CircleCI snippets on the CI/CD page, README section,
  contributor notes in `docker/README.md`.

Validated end-to-end against the offline mock sandbox: full 97-conversation
adversarial run in-container, results persisted to the host through the mount,
`--fail-on` exit-code propagation confirmed. The image is already live on GHCR
(manually pushed `2.7.0`); the next release overwrites it with the
pipeline-built, attested version.

## Type of change

- [x] New feature (non-breaking)
- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
      *(no Python changed — behavior is covered by the new `docker.yml`
      build + smoke-test workflow rather than pytest)*
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)