### PR TITLE
feat(auth): headless user API key authentication (HUMANBOUND_API_KEY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provenance attestation and SBOM; PRs touching the Docker files get an
   automatic build + smoke test. See the new
   [Docker integration docs](https://docs.humanbound.ai/integrations/docker/).
+- **Headless authentication with user API keys.** Set `HUMANBOUND_API_KEY` (an
+  `hb_…` key from `hb api-keys create`) and the CLI authenticates via the
+  `x-api-key` header — no browser login. `HUMANBOUND_PROJECT_ID` and optionally
+  `HUMANBOUND_ORG_ID` select the target for CI, Docker, and automation. Key
+  mode always tests on the platform and surfaces auth failures as clean errors
+  — no silent local fallback, no interactive re-login. See the new
+  [API keys](https://docs.humanbound.ai/management/api-keys/) and
+  [CI/CD](https://docs.humanbound.ai/integrations/cicd/) docs.
+
+### Changed
+- **`hb api-keys create` defaults to least privilege.** `--scopes` is now
+  `--scope` (`read` | `write` | `admin`, cumulative), the default dropped from
+  `admin` to `read`, and new `--org`, `--projects`, and `--expires` options
+  bound a key to explicit organisations/projects and an expiry timestamp.
+  `list`/`update` follow the backend's `scope`/`is_active` field names, and the
+  MCP `hb_create_api_key` / `hb_update_api_key` tools use the same contract.
 
 ### Fixed
 - **Interrupting a local run no longer discards completed conversations**
@@ -42,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **LLM provider API calls no longer follow HTTP redirects**, so credential
   headers can't be re-sent to a redirected host.
+- **Platform API calls no longer follow HTTP redirects either.** The headless
+  key travels in a custom `x-api-key` header, which `requests` — unlike
+  `Authorization` — does not strip on a cross-host redirect, so a redirecting
+  or compromised endpoint could re-send the key to another host. A redirect now
+  surfaces as an explicit error, matching the engine's reject-redirect
+  behavior.
 
 ### Documentation
 - **Clarify that the Ollama "air-gap" provider requires the `[engine]` extra**

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -46,6 +46,27 @@ Opens your browser for OAuth authentication. Credentials are stored locally at `
 | `--port` | Local OAuth callback port (default: 8085) |
 | `--base-url` | API base URL for on-prem deployments |
 
+## Headless (API key)
+
+`hb login` opens a browser for OAuth, which isn't possible in CI/CD, Docker, or cron. There,
+authenticate with a [user API key](management/api-keys.md) instead:
+
+```bash
+export HUMANBOUND_API_KEY=hb_…            # from `hb api-keys create`
+export HUMANBOUND_ORG_ID=<org-id>         # selects the organisation (replaces `hb orgs use`)
+export HUMANBOUND_PROJECT_ID=<project-id> # selects the project (replaces `hb projects use`)
+
+hb test --wait --fail-on high
+```
+
+When `HUMANBOUND_API_KEY` is set the CLI sends the key on every request and skips OAuth
+entirely, acting as the key's owner within the key's scope and org/project selection. No
+credentials are written to `~/.humanbound/`.
+
+Not every command is available this way — see
+[API Keys → Which commands work headlessly](management/api-keys.md#which-commands-work-headlessly)
+for the supported set, and for scoping and rotation.
+
 ## Logout
 
 ```bash

--- a/docs/docs/integrations/cicd.md
+++ b/docs/docs/integrations/cicd.md
@@ -73,8 +73,40 @@ jobs:
 ```
 
 Findings gate the build via `fail-on`, land in **Security → Code scanning** as SARIF, and are
-summarized on the workflow run page. **Local mode** (shown above — your own LLM key, no account)
-works today; **platform mode** (`api-key`, results in the Humanbound dashboard) is coming soon.
+summarized on the workflow run page.
+
+### Local mode vs platform mode
+
+The Action runs in one of two modes — set **exactly one** credential:
+
+| Mode | Credential | Where the engine runs | Results |
+|---|---|---|---|
+| **Local** | `provider-api-key` (your own LLM key) | in the runner | job output + SARIF; no account needed |
+| **Platform** | `api-key` (a Humanbound `hb_…` key) | on humanbound.ai | your dashboard, plus SARIF |
+
+Platform mode uses a [user API key](../management/api-keys.md) — no `hb login`, no browser:
+
+```yaml
+      - uses: humanbound/actions@v1
+        with:
+          api-key: ${{ secrets.HUMANBOUND_API_KEY }}      # hb_… key
+          org-id: ${{ vars.HUMANBOUND_ORG_ID }}
+          project-id: ${{ vars.HUMANBOUND_PROJECT_ID }}
+          fail-on: high
+```
+
+Both ids are required — a headless run has no stored selection. Create the key with the least
+privilege the job needs, pinned to one project:
+
+```bash
+hb api-keys create --name "GitHub CI" --scope write \
+  --org <org-id> --projects <project-id>
+```
+
+!!! note "Requires humanbound ≥ 2.8.0"
+    Headless `HUMANBOUND_API_KEY` auth ships in CLI 2.8.0. The Action checks the installed
+    version and fails with a clear message on older releases — pin `version:` or omit it to
+    get the latest.
 
 !!! tip "Full reference"
     The Action supports many more inputs — scope discovery, test categories, SARIF controls,

--- a/docs/docs/integrations/docker.md
+++ b/docs/docs/integrations/docker.md
@@ -46,7 +46,7 @@ docker run --rm \
 | Variable | What it is |
 |---|---|
 | `HB_API_KEY` | Your **LLM provider** key (OpenAI, Anthropic, …) — powers the attacker/judge models in local mode |
-| `HUMANBOUND_API_KEY` | Your **Humanbound platform** project key — headless platform auth (coming soon) |
+| `HUMANBOUND_API_KEY` | Your **Humanbound user API key** (`hb_…`, from `hb api-keys create`) — headless platform auth via the `x-api-key` header, acting as the key's owner within its scope/selection |
 
 ## Files in, results out
 
@@ -93,8 +93,8 @@ runs on your machine:
 
 `hb status`, project-scoped `hb logs`, and platform-mode `hb test` need platform auth:
 
-- **Today:** log in on the host, then mount your credentials (read-write —
-  the CLI refreshes tokens):
+- **Interactive (mounted credentials):** log in on the host, then mount your
+  credentials (read-write — the CLI refreshes tokens):
 
   ```bash
   hb login   # on the host, once
@@ -102,8 +102,11 @@ runs on your machine:
     ghcr.io/humanbound/humanbound status
   ```
 
-- **Coming soon:** `-e HUMANBOUND_API_KEY=<project-key>` — headless project-key
-  auth, no browser involved.
+- **Headless (API key):** `-e HUMANBOUND_API_KEY=hb_…` authenticates as the
+  key's owner via the `x-api-key` header, so no `hb login` is involved. Pair it
+  with `-e HUMANBOUND_ORG_ID=<id>` and `-e HUMANBOUND_PROJECT_ID=<id>` to select
+  the target. See [API Keys](../management/api-keys.md) for scoping and the list
+  of commands available headlessly.
 
 ## Using the image in CI
 

--- a/docs/docs/management/api-keys.md
+++ b/docs/docs/management/api-keys.md
@@ -1,74 +1,172 @@
 ---
-description: "Create and rotate API keys for programmatic access to Humanbound — for CI/CD pipelines, automation scripts, and SIEM forwarders."
+description: "Create and scope Humanbound user API keys (hb_…) for headless access — CI/CD pipelines, Docker, automation scripts, and SIEM forwarders."
 keywords:
   - API keys
   - hb api-keys command
+  - HUMANBOUND_API_KEY
+  - headless authentication
   - API key scopes
   - programmatic access
   - API key rotation
   - CI/CD authentication
-  - read scope API key
 faq:
   - q: How do I create a Humanbound API key?
-    a: Run `hb api-keys create --name "CI Key"` to create a key. The key value is shown only once during creation — store it securely immediately, because it cannot be retrieved again.
+    a: Run `hb api-keys create --name "CI Key"` to create a key. The key value (an `hb_…` secret) is shown only once during creation — store it securely immediately, because it cannot be retrieved again.
+  - q: How do I use an API key without logging in?
+    a: Set `HUMANBOUND_API_KEY=hb_…` in the environment. The CLI then authenticates with that key instead of `hb login`, acting as the key's owner. Add `HUMANBOUND_PROJECT_ID` (and optionally `HUMANBOUND_ORG_ID`) to select the target project headlessly.
   - q: What happens if I lose my API key?
-    a: API keys are shown only once during creation. If lost, you must revoke the existing key with `hb api-keys delete <id>` and create a new one.
+    a: API keys are shown only once during creation. If lost, revoke the existing key with `hb api-keys delete <id>` and create a new one.
   - q: What scopes are available for API keys?
-    a: Three scopes are available — `admin` for full access including user management and sensitive operations, `write` for creating and modifying projects and running tests, and `read` for view-only access to projects, experiments, and results.
+    a: Three cumulative scopes — `read` (view-only), `write` (adds creating projects and running tests), and `admin` (everything write can do, plus admin-level actions). A route declares a minimum, so a `write` key can also read. The default is `read`.
+  - q: Which organisations can an API key access?
+    a: Only organisations you OWN. A key never reaches an organisation where you are merely a member (admin, developer, or expert), and you can narrow it further with `--org` and `--projects`.
   - q: How do I deactivate an API key without deleting it?
     a: Run `hb api-keys update <id> --inactive` to deactivate a key. You can reactivate it later with `hb api-keys update <id> --active`.
 ---
 
 # API Keys
 
-The `hb api-keys` commands create and manage API keys for programmatic access to the Humanbound platform — the credential CI/CD pipelines, automation scripts, and SIEM forwarders use to authenticate. Keys are issued with one of three scopes (admin, write, read) and shown only once at creation. The commands cover create, list, update (rename, activate, deactivate), and revoke.
+A Humanbound **user API key** (`hb_…`) is the credential for **headless** access — CI/CD
+pipelines, the Docker image, automation scripts, and SIEM forwarders — where an interactive
+`hb login` isn't possible. The key authenticates **as its owner**, bounded by the scope and
+selection you give it. `hb api-keys` covers create, list, update, and revoke.
 
-## List API Keys
+!!! warning "Shown once"
+    The key value appears only in the `create` response. Only a hash is stored, so it can
+    never be retrieved again — copy it straight into your secret store. Lost a key? Revoke
+    it and create a new one.
+
+## Create a key
+
+```bash
+# Least privilege by default: read-only, all orgs you own
+hb api-keys create --name "CI Key"
+
+# Scoped: read-only, one org, one project, expires at a fixed time
+hb api-keys create --name "CI Key" \
+  --scope read \
+  --org 2ab8ff03-2325-4f95-b22e-9262c09682c3 \
+  --projects 68c7169a-6cb1-4f61-825f-bf1fd195ad7d \
+  --expires 1767225600
+```
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `--name` | Label shown in `hb api-keys list` | required |
+| `--scope` | `read` \| `write` \| `admin` (cumulative) | `read` |
+| `--org` | Restrict to organisation id(s); repeatable | all orgs you own |
+| `--projects` | Restrict to project id(s); repeatable | all projects you own |
+| `--expires` | Expiry as epoch seconds | never expires |
+
+`--org` and `--projects` are validated at creation: you can only scope a key to an
+organisation you **own** and to projects inside it. Anything else is rejected immediately,
+so you never end up holding a key that silently can't do anything.
+
+## Use a key headlessly
+
+Set the key in the environment — no `hb login`, no browser:
+
+```bash
+export HUMANBOUND_API_KEY=hb_…            # the key from `create`
+export HUMANBOUND_ORG_ID=<org-id>         # the organisation you own
+export HUMANBOUND_PROJECT_ID=<project-id> # the project to work on
+
+hb test --wait --fail-on high             # run a scan and gate the build
+hb findings                               # read findings
+hb posture                                # read the security posture
+hb report -o report.html                  # export a report
+```
+
+With `HUMANBOUND_API_KEY` set, the CLI sends the key on every request and skips OAuth
+entirely.
+
+See [CI/CD Integration](../integrations/cicd.md) and [Docker](../integrations/docker.md)
+for ready-made pipeline snippets.
+
+## Which commands work headlessly
+
+The connect → test → gate loop a pipeline needs:
+
+| Command | Minimum scope | Notes |
+|---|---|---|
+| `hb connect` | `write` | Provisions a project + integration; use `--yes` for non-interactive |
+| `hb test` | `write` | Pass `--provider-id` to skip provider auto-selection |
+| `hb status <id>` | `read` | Single experiment; `--all` is **not** available headlessly |
+| `hb logs` | `read` | |
+| `hb findings` | `read` | |
+| `hb posture` | `read` | Also `--org` |
+| `hb report` | `read` | Project, `--org`, and `--assessment <id>` reports |
+| `hb assessments list\|show` | `read` | Find the assessment id for `hb report --assessment` |
+| `hb providers` | `read` | List only |
+
+Anything not listed still requires `hb login`. Notably:
+
+- **`hb api-keys …`** — key management is deliberately interactive-only: you cannot mint,
+  rotate, or revoke a key using a key.
+- **`hb orgs`, `hb members`, `hb projects`** — organisation and team administration.
+- **`hb providers add|update|delete`** — provider setup (listing works headlessly).
+
+If a command isn't supported, it fails with a clear error rather than falling back to a
+browser login.
+
+## What a key can reach
+
+Two rules bound every request, and both must pass:
+
+1. **Owner-only.** A key reaches **only organisations its creator owns** — never one where
+   you are merely a member (admin, developer, or expert). Sharing a key with a teammate
+   therefore keeps the blast radius inside your own organisation.
+2. **Scope + selection.** The route's minimum scope must be satisfied (`admin` ⊇ `write` ⊇
+   `read`), and the target org/project must be within the key's `--org` / `--projects`
+   selection.
+
+A key can only ever *narrow* what its owner can do — it never grants more. Key management
+itself (`hb api-keys …`) always requires an interactive login: you cannot mint a key with a key.
+
+!!! tip "Sharing keys with your team"
+    As the organisation owner, create a tightly-scoped key (`--scope read`, one
+    `--projects`, an `--expires`) and hand that to a teammate's pipeline. Requests made with
+    it are attributed to you, the owner — so rotate per consumer rather than sharing one key
+    everywhere.
+
+## List keys
 
 ```bash
 hb api-keys list
 ```
 
-## Create API Key
+Shows id, name, scope, active state, and the key prefix (`hb_` + 8 characters) — never the
+secret itself.
+
+## Update a key
 
 ```bash
-# Create key (shows key once!)
-hb api-keys create --name "CI Key"
-
-# Create scoped key
-hb api-keys create --name "CI Key" --scopes read
+hb api-keys update <id> --name "New Name"   # rename
+hb api-keys update <id> --scope write       # change scope
+hb api-keys update <id> --inactive          # deactivate (requests → 401)
+hb api-keys update <id> --active            # reactivate
 ```
 
-!!! warning "Important"
-    API keys are shown only once during creation. Store them securely. If lost, you must revoke and create a new key.
-
-## Update API Key
+## Revoke a key
 
 ```bash
-# Update name
-hb api-keys update <id> --name "New Name"
-
-# Activate key
-hb api-keys update <id> --active
-
-# Deactivate key
-hb api-keys update <id> --inactive
+hb api-keys delete <id>            # with confirmation
+hb api-keys delete <id> --force    # skip confirmation
 ```
 
-## Revoke API Key
-
-```bash
-# Revoke with confirmation
-hb api-keys delete <id>
-
-# Skip confirmation
-hb api-keys delete <id> --force
-```
+Deactivating (`--inactive`) stops a key immediately and is reversible; deleting is
+permanent. Rotation is create-new → switch the secret → revoke-old.
 
 ## Scopes
 
-- **admin**: Full access including user management and sensitive operations
-- **write**: Create and modify projects, run tests, update findings
-- **read**: View-only access to projects, experiments, and results
+Scopes are **cumulative** — a route declares the minimum it needs, so a higher scope also
+satisfies the lower ones:
+
+- **`read`** — view projects, experiments, findings, posture, and reports *(default)*
+- **`write`** — everything `read` can do, plus create projects (`hb connect`) and run tests (`hb test`)
+- **`admin`** — everything `write` can do, plus admin-level actions
+
+Pick the lowest scope that works: a `read` key can gate a build on existing findings, but
+cannot start a test or create a project.
 
 <!-- faq -->

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -22,10 +22,13 @@ from .config import (
     DEFAULT_TIMEOUT,
     LONG_TIMEOUT,
     TOKEN_FILE,
+    get_api_key,
     get_auth0_audience,
     get_auth0_client_id,
     get_auth0_domain,
     get_base_url,
+    get_organisation_id,
+    get_project_id,
 )
 from .exceptions import (
     APIError,
@@ -310,8 +313,13 @@ class HumanboundClient:
         self._email: str | None = None
         self._default_organisation_id: str | None = None
 
-        # Try to load existing credentials
-        self._load_credentials()
+        # Key mode: org/project come from env, never the credentials file.
+        self._api_key: str | None = get_api_key()
+        if self._api_key:
+            self._organisation_id = get_organisation_id()
+            self._project_id = get_project_id()
+        else:
+            self._load_credentials()
 
     # -------------------------------------------------------------------------
     # Authentication
@@ -470,6 +478,10 @@ class HumanboundClient:
         Returns:
             True if authenticated and token is not expired.
         """
+        # Key mode is stateless — the key itself is the credential.
+        if self._api_key:
+            return True
+
         if not self._api_token:
             return False
 
@@ -632,6 +644,11 @@ class HumanboundClient:
         return self._project_id
 
     @property
+    def api_key(self) -> str | None:
+        """The headless user API key (HUMANBOUND_API_KEY), if auth is key-based."""
+        return self._api_key
+
+    @property
     def username(self) -> str | None:
         """Get current username."""
         return self._username
@@ -665,10 +682,13 @@ class HumanboundClient:
         Returns:
             Headers dictionary.
         """
-        headers = {
-            "Authorization": f"Bearer {self._api_token}",
-            "Content-Type": "application/json",
-        }
+        if self._api_key:
+            headers = {"x-api-key": self._api_key, "Content-Type": "application/json"}
+        else:
+            headers = {
+                "Authorization": f"Bearer {self._api_token}",
+                "Content-Type": "application/json",
+            }
 
         if include_org and self._organisation_id:
             headers["organisation_id"] = self._organisation_id
@@ -698,14 +718,26 @@ class HumanboundClient:
         except ValueError:
             data = {"message": response.text}
 
+        if 300 <= response.status_code < 400:
+            # Never followed — a redirect would replay credential headers cross-host.
+            raise APIError(
+                f"Unexpected redirect (HTTP {response.status_code})",
+                response.status_code,
+                data,
+            )
+
         if response.status_code >= 400:
             message = data.get("message", "Unknown error")
 
             if response.status_code == 404:
                 raise NotFoundError(message, response.status_code, data)
-            elif response.status_code == 401 and "revoked" in message.lower():
-                raise SessionExpiredError(message, response.status_code, data)
-            elif response.status_code == 401 and "expired" in message.lower():
+            elif (
+                response.status_code == 401
+                and not self._api_key
+                and ("revoked" in message.lower() or "expired" in message.lower())
+            ):
+                # Session-mode only: a headless key can't be refreshed, so key-mode
+                # 401s skip this and surface as ForbiddenError instead of re-login.
                 raise SessionExpiredError(message, response.status_code, data)
             elif response.status_code in (401, 403):
                 raise ForbiddenError(message, response.status_code, data)
@@ -747,6 +779,7 @@ class HumanboundClient:
             headers=headers,
             params=params,
             timeout=timeout,
+            allow_redirects=False,
         )
         return self._handle_response(response)
 
@@ -776,6 +809,7 @@ class HumanboundClient:
             headers=self._get_headers(include_org, include_project),
             json=data,
             timeout=timeout,
+            allow_redirects=False,
         )
         return self._handle_response(response)
 
@@ -805,6 +839,7 @@ class HumanboundClient:
             headers=self._get_headers(include_org, include_project),
             json=data,
             timeout=timeout,
+            allow_redirects=False,
         )
         return self._handle_response(response)
 
@@ -831,6 +866,7 @@ class HumanboundClient:
             f"{self.base_url}/{endpoint.lstrip('/')}",
             headers=self._get_headers(include_org, include_project),
             timeout=timeout,
+            allow_redirects=False,
         )
         return self._handle_response(response)
 
@@ -1128,9 +1164,28 @@ class HumanboundClient:
         """List API keys."""
         return self.get("api-keys", params={"page": page, "limit": limit}, include_org=False)
 
-    def create_api_key(self, name: str, scopes: str = "admin") -> dict:
-        """Create a new API key."""
-        return self.post("api-keys", data={"name": name, "scopes": scopes}, include_org=False)
+    def create_api_key(
+        self,
+        name: str,
+        scope: str = "read",
+        organisations: list[str] | None = None,
+        projects: list[str] | None = None,
+        expires_at: int | None = None,
+    ) -> dict:
+        """Create a new user API key.
+
+        Selection/expiry are omitted when not given so the backend applies its
+        least-privilege defaults (scope=read, organisations/projects = all the
+        owner can reach, no expiry).
+        """
+        data: dict = {"name": name, "scope": scope}
+        if organisations:
+            data["organisations"] = list(organisations)
+        if projects:
+            data["projects"] = list(projects)
+        if expires_at is not None:
+            data["expires_at"] = expires_at
+        return self.post("api-keys", data=data, include_org=False)
 
     def delete_api_key(self, key_id: str) -> Any:
         """Delete an API key."""

--- a/humanbound_cli/commands/api_keys.py
+++ b/humanbound_cli/commands/api_keys.py
@@ -63,20 +63,20 @@ def _list_keys(as_json: bool):
         table = Table(title="API Keys")
         table.add_column("ID", style="dim")
         table.add_column("Name", style="bold")
-        table.add_column("Scopes")
+        table.add_column("Scope")
         table.add_column("Active", justify="center")
         table.add_column("Key Prefix", style="dim")
         table.add_column("Created", style="dim")
 
         for key in keys:
-            active = "[green]yes[/green]" if key.get("active", True) else "[red]no[/red]"
+            active = "[green]yes[/green]" if key.get("is_active", True) else "[red]no[/red]"
             key_val = key.get("key", key.get("key_prefix", ""))
             prefix = (key_val[:12] + "...") if len(str(key_val)) > 12 else str(key_val)
 
             table.add_row(
                 str(key.get("id", "")),
                 key.get("name", ""),
-                key.get("scopes", ""),
+                key.get("scope", ""),
                 active,
                 prefix,
                 str(key.get("created_at", ""))[:10],
@@ -95,12 +95,37 @@ def _list_keys(as_json: bool):
 @api_keys_group.command("create")
 @click.option("--name", required=True, help="Name for the API key")
 @click.option(
-    "--scopes",
-    type=click.Choice(["admin", "write", "read"]),
-    default="admin",
-    help="Key permission scope",
+    "--scope",
+    type=click.Choice(["read", "write", "admin"]),
+    default="read",
+    help="Key permission scope (cumulative: admin >= write >= read). Default: read.",
 )
-def create_key(name: str, scopes: str):
+@click.option(
+    "--org",
+    "organisations",
+    multiple=True,
+    help="Restrict the key to these organisation id(s) (repeatable). Default: all the owner can reach.",
+)
+@click.option(
+    "--projects",
+    "projects",
+    multiple=True,
+    help="Restrict the key to these project id(s) (repeatable). Default: all the owner can reach.",
+)
+@click.option(
+    "--expires",
+    "expires_at",
+    type=int,
+    default=None,
+    help="Expiry as epoch seconds (default: never expires).",
+)
+def create_key(
+    name: str,
+    scope: str,
+    organisations: tuple[str, ...],
+    projects: tuple[str, ...],
+    expires_at: int | None,
+):
     """Create a new API key.
 
     The full key is shown only once after creation - save it immediately.
@@ -114,7 +139,13 @@ def create_key(name: str, scopes: str):
 
     try:
         with console.status("Creating API key..."):
-            response = client.create_api_key(name, scopes)
+            response = client.create_api_key(
+                name,
+                scope,
+                organisations=list(organisations) or None,
+                projects=list(projects) or None,
+                expires_at=expires_at,
+            )
 
         key_value = response.get("key", response.get("api_key", ""))
 
@@ -129,7 +160,11 @@ def create_key(name: str, scopes: str):
         )
 
         console.print(f"\n  Name: [bold]{name}[/bold]")
-        console.print(f"  Scopes: {scopes}")
+        console.print(f"  Scope: {scope}")
+        console.print(f"  Organisations: {list(organisations) or ['*']}")
+        console.print(f"  Projects: {list(projects) or ['*']}")
+        if expires_at is not None:
+            console.print(f"  Expires at: {expires_at}")
         console.print(f"  ID: [dim]{response.get('id', '')}[/dim]")
 
     except NotAuthenticatedError:
@@ -143,11 +178,9 @@ def create_key(name: str, scopes: str):
 @api_keys_group.command("update")
 @click.argument("key_id")
 @click.option("--name", help="New key name")
-@click.option(
-    "--scopes", type=click.Choice(["admin", "write", "read"]), help="New permission scope"
-)
+@click.option("--scope", type=click.Choice(["read", "write", "admin"]), help="New permission scope")
 @click.option("--active/--inactive", default=None, help="Activate or deactivate key")
-def update_key(key_id: str, name: str, scopes: str, active):
+def update_key(key_id: str, name: str, scope: str, active):
     """Update an API key.
 
     KEY_ID: API key UUID (or partial ID).
@@ -159,9 +192,9 @@ def update_key(key_id: str, name: str, scopes: str, active):
         console.print("[red]Not authenticated.[/red] Run 'hb login' first.")
         raise SystemExit(1)
 
-    if name is None and scopes is None and active is None:
+    if name is None and scope is None and active is None:
         console.print(
-            "[yellow]Nothing to update.[/yellow] Provide --name, --scopes, or --active/--inactive."
+            "[yellow]Nothing to update.[/yellow] Provide --name, --scope, or --active/--inactive."
         )
         raise SystemExit(1)
 
@@ -172,10 +205,10 @@ def update_key(key_id: str, name: str, scopes: str, active):
         payload = {}
         if name is not None:
             payload["name"] = name
-        if scopes is not None:
-            payload["scopes"] = scopes
+        if scope is not None:
+            payload["scope"] = scope
         if active is not None:
-            payload["active"] = active
+            payload["is_active"] = active
 
         with console.status("Updating API key..."):
             client.update_api_key(key_id, payload)

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -413,7 +413,12 @@ def test_command(
             client = runner.client
             if not client.project_id:
                 console.print("[yellow]No project selected.[/yellow]")
-                console.print("Use 'hb projects use <id>' to select a project first.")
+                if client.api_key:
+                    console.print(
+                        "Set the [bold]HUMANBOUND_PROJECT_ID[/bold] env var to the target project."
+                    )
+                else:
+                    console.print("Use 'hb projects use <id>' to select a project first.")
                 raise SystemExit(1)
         elif runner is None:
             console.print("[red]Not authenticated.[/red] Run 'hb login' first.")

--- a/humanbound_cli/config.py
+++ b/humanbound_cli/config.py
@@ -31,6 +31,31 @@ def get_base_url() -> str:
     return os.environ.get("HUMANBOUND_BASE_URL", DEFAULT_BASE_URL)
 
 
+def _env_or_none(name: str) -> str | None:
+    """Return the trimmed env value, or None when unset, empty, or whitespace."""
+    value = os.environ.get(name, "").strip()
+    return value or None
+
+
+def get_api_key() -> str | None:
+    """Get the user API key (hb_… secret) for headless auth, if set.
+
+    When present, the client authenticates via the `x-api-key` header and skips
+    the OAuth/credentials flow entirely.
+    """
+    return _env_or_none("HUMANBOUND_API_KEY")
+
+
+def get_organisation_id() -> str | None:
+    """Org id for headless selection (HUMANBOUND_ORG_ID), if set."""
+    return _env_or_none("HUMANBOUND_ORG_ID")
+
+
+def get_project_id() -> str | None:
+    """Project id for headless selection (HUMANBOUND_PROJECT_ID), if set."""
+    return _env_or_none("HUMANBOUND_PROJECT_ID")
+
+
 def get_auth0_domain() -> str:
     """Get Auth0 domain from environment or default."""
     return os.environ.get("HUMANBOUND_AUTH0_DOMAIN", AUTH0_DOMAIN)

--- a/humanbound_cli/engine/__init__.py
+++ b/humanbound_cli/engine/__init__.py
@@ -15,8 +15,11 @@ def get_runner(force_local: bool = False) -> TestRunner:
     """Select runner based on auth state. This is the ONLY decision point.
 
     - force_local=True → always LocalTestRunner (--local flag)
-    - Authenticated → PlatformTestRunner
-    - Not authenticated → LocalTestRunner
+    - Headless API key (HUMANBOUND_API_KEY) → always PlatformTestRunner, never a
+      silent local fallback: an invalid key/selection surfaces as the backend's
+      401/403 instead of quietly running locally.
+    - OAuth-authenticated with a selected project → PlatformTestRunner
+    - Otherwise → LocalTestRunner
     """
     if force_local:
         from .local_runner import LocalTestRunner
@@ -26,7 +29,7 @@ def get_runner(force_local: bool = False) -> TestRunner:
     from ..client import HumanboundClient
 
     client = HumanboundClient()
-    if client.is_authenticated() and client.project_id:
+    if client.api_key or (client.is_authenticated() and client.project_id):
         from .platform_runner import PlatformTestRunner
 
         return PlatformTestRunner(client)

--- a/humanbound_cli/main.py
+++ b/humanbound_cli/main.py
@@ -197,7 +197,7 @@ def status_alias(ctx, experiment_id: str, watch: bool, show_all: bool):
 
 def main():
     """Entrypoint with session expiry handling and telemetry init."""
-    from .exceptions import NotAuthenticatedError, SessionExpiredError
+    from .exceptions import APIError, NotAuthenticatedError, SessionExpiredError
 
     telemetry_pkg.maybe_fire_startup_events()
     atexit.register(telemetry_pkg.shutdown)
@@ -215,6 +215,9 @@ def main():
         client.logout()
         client.login()
         console.print("\n[green]Logged in.[/green] Please re-run your command.")
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
     except NotAuthenticatedError:
         # Fire gated_command_hit before re-raising so user sees the original UX
         telemetry_pkg.fire_gated_command_hit()

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -1136,36 +1136,36 @@ def hb_list_api_keys(page: int = 1, limit: int = 50) -> str:
 
 
 @mcp.tool()
-def hb_create_api_key(name: str, scopes: str = "admin") -> str:
+def hb_create_api_key(name: str, scope: str = "read") -> str:
     """Create a new API key.
 
     Args:
         name: Key name/label.
-        scopes: Comma-separated scopes (default 'admin').
+        scope: Permission scope 'read', 'write', or 'admin' (cumulative; default 'read').
     """
     try:
         client = _get_client()
-        return _ok(client.create_api_key(name, scopes=scopes))
+        return _ok(client.create_api_key(name, scope=scope))
     except HumanboundError as e:
         return _err(e)
 
 
 @mcp.tool()
-def hb_update_api_key(key_id: str, name: str | None = None, scopes: str | None = None) -> str:
+def hb_update_api_key(key_id: str, name: str | None = None, scope: str | None = None) -> str:
     """Update an API key.
 
     Args:
         key_id: API key UUID.
         name: New name.
-        scopes: New scopes.
+        scope: New permission scope 'read', 'write', or 'admin' (cumulative).
     """
     try:
         client = _get_client()
         data = {}
         if name is not None:
             data["name"] = name
-        if scopes is not None:
-            data["scopes"] = scopes
+        if scope is not None:
+            data["scope"] = scope
         return _ok(client.update_api_key(key_id, data))
     except HumanboundError as e:
         return _err(e)

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -71,16 +71,54 @@ class TestHappyPath:
         result = runner.invoke(cli, ["api-keys", "create", "--name", "test-key"])
         assert result.exit_code == 0
         assert "hb_secret_xxx" in result.output
-        mock.create_api_key.assert_called_once_with("test-key", "admin")
+        # default scope is read (least privilege); no selection/expiry sent
+        mock.create_api_key.assert_called_once_with(
+            "test-key", "read", organisations=None, projects=None, expires_at=None
+        )
 
     @patch(PATCH_TARGET)
-    def test_create_api_key_with_scopes(self, MockClient):
+    def test_create_api_key_with_scope(self, MockClient):
         mock = _make_client()
-        mock.create_api_key.return_value = {"id": "key-new", "key": "hb_read_xxx"}
+        mock.create_api_key.return_value = {"id": "key-new", "key": "hb_write_xxx"}
         MockClient.return_value = mock
-        result = runner.invoke(cli, ["api-keys", "create", "--name", "reader", "--scopes", "read"])
+        result = runner.invoke(cli, ["api-keys", "create", "--name", "writer", "--scope", "write"])
         assert result.exit_code == 0
-        mock.create_api_key.assert_called_once_with("reader", "read")
+        mock.create_api_key.assert_called_once_with(
+            "writer", "write", organisations=None, projects=None, expires_at=None
+        )
+
+    @patch(PATCH_TARGET)
+    def test_create_api_key_with_selection_and_expiry(self, MockClient):
+        mock = _make_client()
+        mock.create_api_key.return_value = {"id": "key-new", "key": "hb_scoped_xxx"}
+        MockClient.return_value = mock
+        result = runner.invoke(
+            cli,
+            [
+                "api-keys",
+                "create",
+                "--name",
+                "ci",
+                "--scope",
+                "read",
+                "--org",
+                "org-1",
+                "--projects",
+                "proj-1",
+                "--projects",
+                "proj-2",
+                "--expires",
+                "1700000000",
+            ],
+        )
+        assert result.exit_code == 0
+        mock.create_api_key.assert_called_once_with(
+            "ci",
+            "read",
+            organisations=["org-1"],
+            projects=["proj-1", "proj-2"],
+            expires_at=1700000000,
+        )
 
     @patch(PATCH_TARGET)
     def test_delete_api_key_with_force(self, MockClient):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -546,3 +546,148 @@ class TestDiscoverTargets:
     def test_requires_organisation(self, unauthenticated_client):
         with pytest.raises(ValidationError):
             unauthenticated_client.discover_targets("openai", {"api_key": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Headless user API key mode (HUMANBOUND_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyMode:
+    """HUMANBOUND_API_KEY → authenticate via x-api-key, skip OAuth/credentials."""
+
+    def _client(self, tmp_path, monkeypatch, **env):
+        config_dir = tmp_path / ".humanbound"
+        config_dir.mkdir(exist_ok=True)
+        token_file = config_dir / "credentials.json"
+        monkeypatch.setattr("humanbound_cli.client.CONFIG_DIR", config_dir)
+        monkeypatch.setattr("humanbound_cli.client.TOKEN_FILE", token_file)
+        monkeypatch.setattr("humanbound_cli.config.CONFIG_DIR", config_dir)
+        monkeypatch.setattr("humanbound_cli.config.TOKEN_FILE", token_file)
+        for k in ("HUMANBOUND_API_KEY", "HUMANBOUND_ORG_ID", "HUMANBOUND_PROJECT_ID"):
+            monkeypatch.delenv(k, raising=False)
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        return HumanboundClient(base_url="http://test.local/api")
+
+    def test_key_makes_authenticated_without_token(self, tmp_path, monkeypatch):
+        c = self._client(tmp_path, monkeypatch, HUMANBOUND_API_KEY="hb_abc123")
+        assert c.api_key == "hb_abc123"
+        assert c._api_token is None  # no OAuth token loaded
+        assert c.is_authenticated() is True
+
+    def test_key_env_whitespace_is_stripped(self, tmp_path, monkeypatch):
+        # CI secrets often carry a trailing newline (--env-file, $(cat key));
+        # a raw \n in a header value makes requests raise InvalidHeader.
+        c = self._client(
+            tmp_path,
+            monkeypatch,
+            HUMANBOUND_API_KEY=" hb_abc123\n",
+            HUMANBOUND_ORG_ID="org-1\n",
+            HUMANBOUND_PROJECT_ID=" proj-1 ",
+        )
+        assert c.api_key == "hb_abc123"
+        assert c._organisation_id == "org-1"
+        assert c._project_id == "proj-1"
+
+    def test_headers_use_x_api_key_not_bearer(self, tmp_path, monkeypatch):
+        c = self._client(
+            tmp_path,
+            monkeypatch,
+            HUMANBOUND_API_KEY="hb_abc123",
+            HUMANBOUND_ORG_ID="org-1",
+            HUMANBOUND_PROJECT_ID="proj-1",
+        )
+        headers = c._get_headers(include_org=True, include_project=True)
+        assert headers["x-api-key"] == "hb_abc123"
+        assert "Authorization" not in headers
+        assert headers["organisation_id"] == "org-1"
+        assert headers["project_id"] == "proj-1"
+
+    def test_no_key_keeps_bearer(self, tmp_path, monkeypatch):
+        c = self._client(tmp_path, monkeypatch)  # no env key
+        c._api_token = "tok"
+        headers = c._get_headers()
+        assert headers["Authorization"] == "Bearer tok"
+        assert "x-api-key" not in headers
+
+    def test_key_mode_expired_401_does_not_trigger_relogin(self, tmp_path, monkeypatch):
+        # A headless key can't re-authenticate: its "expired" 401 must surface as a plain
+        # error (ForbiddenError), NOT SessionExpiredError (which drives the OAuth re-login).
+        from humanbound_cli.exceptions import ForbiddenError, SessionExpiredError
+
+        c = self._client(tmp_path, monkeypatch, HUMANBOUND_API_KEY="hb_abc")
+        resp = MagicMock(status_code=401)
+        resp.json.return_value = {"message": "API key has expired."}
+        with pytest.raises(ForbiddenError):
+            c._handle_response(resp)
+
+    def test_session_mode_expired_401_is_session_expiry(self, tmp_path, monkeypatch):
+        # Without a key, an expired session 401 still maps to SessionExpiredError (re-login).
+        from humanbound_cli.exceptions import SessionExpiredError
+
+        c = self._client(tmp_path, monkeypatch)  # no key
+        c._api_token = "tok"
+        resp = MagicMock(status_code=401)
+        resp.json.return_value = {"message": "Session token expired."}
+        with pytest.raises(SessionExpiredError):
+            c._handle_response(resp)
+
+
+class TestClientDisablesRedirects:
+    """Credential-bearing requests must not follow redirects.
+
+    ``requests`` strips only ``Authorization`` on a cross-host redirect, not
+    custom headers such as ``x-api-key``, so a redirecting or compromised
+    endpoint could re-send a headless key to another host. Mirrors the LLM
+    pinger and bot HTTP/SSE reject-redirect behavior (see test_llm_pinger.py).
+    """
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_get_disables_redirects(self, mock_get, client):
+        mock_get.return_value = _mock_response(200, {})
+        client.get("projects")
+        assert mock_get.call_args.kwargs.get("allow_redirects") is False
+
+    @patch("humanbound_cli.client.requests.post")
+    def test_post_disables_redirects(self, mock_post, client):
+        mock_post.return_value = _mock_response(200, {})
+        client.post("projects", data={})
+        assert mock_post.call_args.kwargs.get("allow_redirects") is False
+
+    @patch("humanbound_cli.client.requests.put")
+    def test_put_disables_redirects(self, mock_put, client):
+        mock_put.return_value = _mock_response(200, {})
+        client.put("projects/1", data={})
+        assert mock_put.call_args.kwargs.get("allow_redirects") is False
+
+    @patch("humanbound_cli.client.requests.delete")
+    def test_delete_disables_redirects(self, mock_delete, client):
+        mock_delete.return_value = _mock_response(204)
+        client.delete("projects/1")
+        assert mock_delete.call_args.kwargs.get("allow_redirects") is False
+
+    def test_3xx_surfaces_as_api_error(self, client):
+        resp = _mock_response(302, {"message": "Found"})
+        with pytest.raises(APIError):
+            client._handle_response(resp)
+
+
+class TestGetRunnerKeyMode:
+    """get_runner(): a headless key selects PlatformTestRunner with no local fallback."""
+
+    def test_key_selects_platform_runner(self, monkeypatch):
+        from humanbound_cli.engine import get_runner
+        from humanbound_cli.engine.platform_runner import PlatformTestRunner
+
+        monkeypatch.setenv("HUMANBOUND_API_KEY", "hb_abc123")
+        runner = get_runner()
+        assert isinstance(runner, PlatformTestRunner)
+        assert runner.client.api_key == "hb_abc123"
+
+    def test_force_local_wins_over_key(self, monkeypatch):
+        from humanbound_cli.engine import get_runner
+        from humanbound_cli.engine.local_runner import LocalTestRunner
+
+        monkeypatch.setenv("HUMANBOUND_API_KEY", "hb_abc123")
+        assert isinstance(get_runner(force_local=True), LocalTestRunner)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Tests for MCP server API-key tools: alignment with the client's scope contract."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mcp")  # MCP SDK ships in the [mcp] extra
+
+from humanbound_cli import mcp_server
+
+
+@pytest.fixture
+def client(monkeypatch):
+    c = MagicMock()
+    monkeypatch.setattr(mcp_server, "_client", c)
+    return c
+
+
+class TestApiKeyTools:
+    """The client renamed scopes→scope (default read); the MCP tools must match."""
+
+    def test_create_defaults_to_read_scope(self, client):
+        client.create_api_key.return_value = {"id": "k1"}
+        mcp_server.hb_create_api_key("ci key")
+        client.create_api_key.assert_called_once_with("ci key", scope="read")
+
+    def test_create_passes_explicit_scope(self, client):
+        client.create_api_key.return_value = {"id": "k1"}
+        mcp_server.hb_create_api_key("ci key", scope="admin")
+        client.create_api_key.assert_called_once_with("ci key", scope="admin")
+
+    def test_update_sends_singular_scope_field(self, client):
+        client.update_api_key.return_value = {"id": "k1"}
+        mcp_server.hb_update_api_key("key-1", scope="admin")
+        client.update_api_key.assert_called_once_with("key-1", {"scope": "admin"})


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Adds headless authentication with user API keys for CI, Docker, and automation.

Set `HUMANBOUND_API_KEY` (an `hb_…` key from `hb api-keys create`) and the CLI
authenticates via the `x-api-key` header — no browser login — acting as the
key's owner within the key's scope. `HUMANBOUND_ORG_ID` / `HUMANBOUND_PROJECT_ID`
select org/project headlessly.

Key mode is stateless and un-refreshable, so its 401s surface as clean errors
instead of triggering the interactive re-login flow, and `hb test` always uses
the platform runner — an invalid key or selection fails loudly rather than
silently falling back to a local run.

`hb api-keys` aligns with the backend contract: `--scopes` becomes `--scope`
(`read`|`write`|`admin`, cumulative) with a least-privilege default of `read`
(was `admin`), plus `--org`/`--projects`/`--expires` to bound a key.
`list`/`update` use the `scope`/`is_active` field names, and the MCP
`hb_create_api_key` / `hb_update_api_key` tools follow the same contract.

Hardening from review:

- Platform API calls pass `allow_redirects=False` and treat 3xx as an error:
  `requests` strips only `Authorization` on a cross-host redirect, not custom
  headers, so a redirecting endpoint could re-send `x-api-key` to another host
  (same fix as the engine's LLM pingers in 5f3bf1b).
- Env values are trimmed on read: CI secret files often carry a trailing
  newline, which `requests` rejects inside a header value, and trailing spaces
  caused opaque 401s. Whitespace-only values cleanly fall back to OAuth mode.
- The top-level `APIError` handler prints the backend message and exits 1
  instead of dumping an unhandled traceback.

Docs: new API-keys management and CI/CD pages; headless-auth sections in the
authentication and Docker pages.

## Type of change

- [x] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->