### PR TITLE
chore(release): prepare v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] — 2026-07-30
+
 ### Added
 - **Official Docker image** — `ghcr.io/humanbound/humanbound`, published to
   GitHub Container Registry on every release (multi-arch `linux/amd64` +
@@ -565,7 +567,8 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.7.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.8.0...HEAD
+[2.8.0]: https://github.com/humanbound/humanbound/releases/tag/v2.8.0
 [2.7.0]: https://github.com/humanbound/humanbound/releases/tag/v2.7.0
 [2.6.0]: https://github.com/humanbound/humanbound/releases/tag/v2.6.0
 [2.5.0]: https://github.com/humanbound/humanbound/releases/tag/v2.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.7.0"
+version = "2.8.0"
 description = "Open-source adversarial testing engine, SDK, and CLI for AI agents."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

Prepare the v2.8.0 release: move the `[Unreleased]` entries under a dated
`## [2.8.0] — 2026-07-30` heading, refresh the comparison links at the bottom
of the changelog, and bump the package version in `pyproject.toml` ahead of
tagging `v2.8.0`.

Headline changes shipping in this release: headless authentication with user
API keys (`HUMANBOUND_API_KEY`) for CI/Docker/automation, and the official
Docker image on GHCR (#94). Also ships the interrupted-run fix (#75, #90), the
`--quick` help correction (#72, #89), and the no-redirect hardening on both the
engine's LLM provider calls (#91) and the platform client.

No code changes — after merge, tagging `v2.8.0` on main triggers the release
workflow (PyPI publish + GitHub Release + GHCR image).

## Type of change

- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix (N/A — no behavior change)
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]` (entries moved to the dated `[2.8.0]` section)
- [x] Docs updated on `docs.humanbound.ai` (N/A — release chore)
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- none -->
