### PR TITLE
security(local): write test result artifacts at 0600 under 0700 dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - **Local test result artifacts are written atomically at `0600`** under
-  `.humanbound/results/` directories hardened to `0700`. `meta.json` and
-  `logs.jsonl` retain raw prompts, model replies, and often endpoint secrets;
-  they previously inherited the process umask (commonly world-readable on first
-  write). They now use the same secure writer as `credentials.json`.
+  `.humanbound/results/` directories hardened to `0700`. `logs.jsonl` retains
+  every attack prompt and the agent's raw replies (including disclosures the
+  agent wasn't supposed to make); they previously inherited the process umask
+  (commonly world-readable on first write). They now use the same secure writer
+  as `credentials.json`.
 
 - **Local secret files are written atomically at `0600`** (#67, thanks
   @JChario). `credentials.json`, the provider `config.yaml`, and the telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trace still reaches the error callback and DEBUG logging.
 
 ### Security
+- **Local test result artifacts are written atomically at `0600`** under
+  `.humanbound/results/` directories hardened to `0700`. `meta.json` and
+  `logs.jsonl` retain raw prompts, model replies, and often endpoint secrets;
+  they previously inherited the process umask (commonly world-readable on first
+  write). They now use the same secure writer as `credentials.json`.
+
 - **Local secret files are written atomically at `0600`** (#67, thanks
   @JChario). `credentials.json`, the provider `config.yaml`, and the telemetry
   state file could briefly exist world-readable on first write (created at the

--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -14,11 +14,38 @@ import time
 import traceback
 from pathlib import Path
 
+from humanbound_cli.config import write_secure_file
+
 from .callbacks import EngineCallbacks
 from .presenter import run as presenter_run
 from .runner import PaginatedLogs, Posture, TestConfig, TestResult, TestRunner, TestStatus
 
 logger = logging.getLogger("humanbound.engine.local")
+
+
+def _ensure_private_dir(path: Path) -> None:
+    """Create ``path`` (and parents) with owner-only (0700) permissions.
+
+    Local result trees contain raw prompts, model replies, and often secrets
+    from the target endpoint. Matching credential storage, directories must not
+    inherit a world-readable umask.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except (OSError, NotImplementedError):
+        pass
+    # Also tighten ancestors we own under .humanbound/results/
+    try:
+        results_root = path
+        while results_root.name != "results" and results_root != results_root.parent:
+            results_root = results_root.parent
+        if results_root.name == "results":
+            results_root.chmod(0o700)
+            if results_root.parent.name == ".humanbound":
+                results_root.parent.chmod(0o700)
+    except (OSError, NotImplementedError):
+        pass
 
 
 class _LocalRun:
@@ -173,7 +200,7 @@ class _LocalRun:
         )
 
         results_dir = Path(".humanbound/results") / self.experiment_id
-        results_dir.mkdir(parents=True, exist_ok=True)
+        _ensure_private_dir(results_dir)
 
         # Build validated ExperimentMeta
         exp_results = ExperimentResults()
@@ -209,14 +236,20 @@ class _LocalRun:
             completed_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
         )
 
-        (results_dir / "meta.json").write_text(json.dumps(meta.model_dump(), indent=2, default=str))
+        # meta.json / logs.jsonl hold prompts, replies, and often endpoint
+        # secrets — write atomically at 0600 like credentials.json.
+        write_secure_file(
+            results_dir / "meta.json",
+            json.dumps(meta.model_dump(), indent=2, default=str),
+        )
 
         # logs.jsonl — validated LogEntry schema
-        with open(results_dir / "logs.jsonl", "w") as f:
-            for log in self.logs:
-                log_obj = LogsAnonymous(**log) if isinstance(log, dict) else log
-                public = log_obj.to_public()
-                f.write(json.dumps(public.model_dump(), default=str) + "\n")
+        log_lines = []
+        for log in self.logs:
+            log_obj = LogsAnonymous(**log) if isinstance(log, dict) else log
+            public = log_obj.to_public()
+            log_lines.append(json.dumps(public.model_dump(), default=str))
+        write_secure_file(results_dir / "logs.jsonl", "\n".join(log_lines) + ("\n" if log_lines else ""))
 
         logger.info(f"Results saved to {results_dir}")
 

--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -26,9 +26,9 @@ logger = logging.getLogger("humanbound.engine.local")
 def _ensure_private_dir(path: Path) -> None:
     """Create ``path`` (and parents) with owner-only (0700) permissions.
 
-    Local result trees contain raw prompts, model replies, and often secrets
-    from the target endpoint. Matching credential storage, directories must not
-    inherit a world-readable umask.
+    Local result trees contain attack prompts and the agent's raw replies.
+    Matching credential storage, directories must not inherit a world-readable
+    umask.
     """
     path.mkdir(parents=True, exist_ok=True)
     try:
@@ -236,8 +236,8 @@ class _LocalRun:
             completed_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
         )
 
-        # meta.json / logs.jsonl hold prompts, replies, and often endpoint
-        # secrets — write atomically at 0600 like credentials.json.
+        # meta.json / logs.jsonl hold attack prompts and agent replies —
+        # write atomically at 0600 like credentials.json.
         write_secure_file(
             results_dir / "meta.json",
             json.dumps(meta.model_dump(), indent=2, default=str),
@@ -249,7 +249,10 @@ class _LocalRun:
             log_obj = LogsAnonymous(**log) if isinstance(log, dict) else log
             public = log_obj.to_public()
             log_lines.append(json.dumps(public.model_dump(), default=str))
-        write_secure_file(results_dir / "logs.jsonl", "\n".join(log_lines) + ("\n" if log_lines else ""))
+        write_secure_file(
+            results_dir / "logs.jsonl",
+            "\n".join(log_lines) + ("\n" if log_lines else ""),
+        )
 
         logger.info(f"Results saved to {results_dir}")
 

--- a/tests/unit/test_local_result_permissions.py
+++ b/tests/unit/test_local_result_permissions.py
@@ -3,8 +3,8 @@
 """Local test results must not be world-readable.
 
 Local runs write meta.json / logs.jsonl under .humanbound/results/. Those files
-contain prompts, model replies, and often endpoint credentials — they must be
-created with the same owner-only (0600 / 0700) contract as credentials.json.
+contain attack prompts and the agent's raw replies — they must be created with
+the same owner-only (0600 / 0700) contract as credentials.json.
 """
 
 import json
@@ -14,12 +14,20 @@ from pathlib import Path
 
 import pytest
 
-from humanbound_cli.engine.local_runner import _LocalRun, _ensure_private_dir
+from humanbound_cli.engine.local_runner import _ensure_private_dir, _LocalRun
 from humanbound_cli.engine.runner import TestConfig
 
 
+@pytest.fixture
+def umask_022():
+    """Pin a permissive umask so permission tests fail against the unfixed path."""
+    old = os.umask(0o022)
+    yield
+    os.umask(old)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
-def test_ensure_private_dir_is_owner_only(tmp_path, monkeypatch):
+def test_ensure_private_dir_is_owner_only(tmp_path, monkeypatch, umask_022):
     monkeypatch.chdir(tmp_path)
     target = Path(".humanbound/results/exp-demo")
     _ensure_private_dir(target)
@@ -30,7 +38,7 @@ def test_ensure_private_dir_is_owner_only(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
-def test_save_results_writes_owner_only_artifacts(tmp_path, monkeypatch):
+def test_save_results_writes_owner_only_artifacts(tmp_path, monkeypatch, umask_022):
     monkeypatch.chdir(tmp_path)
     config = TestConfig(
         name="perm-test",
@@ -69,10 +77,9 @@ def test_save_results_writes_owner_only_artifacts(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
-def test_naive_write_text_would_be_world_readable(tmp_path, monkeypatch):
+def test_naive_write_text_would_be_world_readable(tmp_path, monkeypatch, umask_022):
     """Document the pre-fix failure mode: umask 022 makes write_text world-readable."""
     monkeypatch.chdir(tmp_path)
-    os.umask(0o022)
     leaky = Path("leaky.json")
     leaky.write_text("{}")
     mode = stat.S_IMODE(leaky.stat().st_mode)

--- a/tests/unit/test_local_result_permissions.py
+++ b/tests/unit/test_local_result_permissions.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Local test results must not be world-readable.
+
+Local runs write meta.json / logs.jsonl under .humanbound/results/. Those files
+contain prompts, model replies, and often endpoint credentials — they must be
+created with the same owner-only (0600 / 0700) contract as credentials.json.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from humanbound_cli.engine.local_runner import _LocalRun, _ensure_private_dir
+from humanbound_cli.engine.runner import TestConfig
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
+def test_ensure_private_dir_is_owner_only(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = Path(".humanbound/results/exp-demo")
+    _ensure_private_dir(target)
+    assert target.is_dir()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+    assert stat.S_IMODE(Path(".humanbound/results").stat().st_mode) == 0o700
+    assert stat.S_IMODE(Path(".humanbound").stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
+def test_save_results_writes_owner_only_artifacts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = TestConfig(
+        name="perm-test",
+        endpoint={"url": "https://example.test/chat"},
+        test_category="owasp/llm",
+        testing_level="unit",
+    )
+    run = _LocalRun("exp-perm-test", config)
+    run.status = "Finished"
+    run.results = {
+        "stats": {},
+        "insights": [],
+        "posture": None,
+        "exec_t": {},
+    }
+    run.logs = [
+        {
+            "thread_id": "t1",
+            "conversation": [{"u": "secret prompt", "a": "model reply"}],
+            "result": "pass",
+            "gen_category": "test",
+        }
+    ]
+    run._save_results()
+
+    results_dir = Path(".humanbound/results/exp-perm-test")
+    meta = results_dir / "meta.json"
+    logs = results_dir / "logs.jsonl"
+    assert meta.exists()
+    assert logs.exists()
+    assert json.loads(meta.read_text())["id"] == "exp-perm-test"
+    assert "secret prompt" in logs.read_text()
+    assert stat.S_IMODE(meta.stat().st_mode) == 0o600
+    assert stat.S_IMODE(logs.stat().st_mode) == 0o600
+    assert stat.S_IMODE(results_dir.stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not enforced on Windows")
+def test_naive_write_text_would_be_world_readable(tmp_path, monkeypatch):
+    """Document the pre-fix failure mode: umask 022 makes write_text world-readable."""
+    monkeypatch.chdir(tmp_path)
+    os.umask(0o022)
+    leaky = Path("leaky.json")
+    leaky.write_text("{}")
+    mode = stat.S_IMODE(leaky.stat().st_mode)
+    # On a typical umask 022 this is 0644 — group/other readable.
+    assert mode & stat.S_IROTH, f"expected other-readable under umask 022, got {oct(mode)}"


### PR DESCRIPTION
## Summary
- Local `meta.json` / `logs.jsonl` under `.humanbound/results/` hold prompts, model replies, and often endpoint secrets, but were created with `write_text` at the process umask (commonly world-readable).
- Results now use the same atomic owner-only (`0600`) writer as `credentials.json`, and result directories are hardened to `0700`.
- Adds regression tests that lock the permission contract under umask `022`.

Independent of open issues; extends credential hardening from #67 to local test artifacts.

## Test plan
- [x] `pytest tests/unit/test_local_result_permissions.py`
- [x] Spot-check a local `hb test --wait` run: files `600`, dirs `700`