### PR TITLE
security(auth): bind OAuth callbacks to loopback and block discovery redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **OAuth callback listeners are loopback-only and path-validated.** Login and
   browser-session logout now bind only to `127.0.0.1`; login accepts an
-  authorization response only at its registered `/callback` path. Discovery
-  persistence requests also reject redirects, preventing their credential and
-  nonce headers from being replayed to a redirected host.
+  authorization response only at its registered `/callback` path. Remaining
+  auth-bearing client calls that bypassed the shared wrappers also refuse
+  redirects (`persist_discovery`, token exchange, refresh, logout, and API
+  session exchange), closing the gap left after #97 — including API-key mode
+  where `x-api-key` would otherwise be forwarded across a hostname change.
 - **Local secret files are written atomically at `0600`** (#67, thanks
   @JChario). `credentials.json`, the provider `config.yaml`, and the telemetry
   state file could briefly exist world-readable on first write (created at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trace still reaches the error callback and DEBUG logging.
 
 ### Security
+- **OAuth callback listeners are loopback-only and path-validated.** Login and
+  browser-session logout now bind only to `127.0.0.1`; login accepts an
+  authorization response only at its registered `/callback` path. Discovery
+  persistence requests also reject redirects, preventing their credential and
+  nonce headers from being replayed to a redirected host.
 - **Local secret files are written atomically at `0600`** (#67, thanks
   @JChario). `credentials.json`, the provider `config.yaml`, and the telemetry
   state file could briefly exist world-readable on first write (created at the

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -295,6 +295,8 @@ LOGOUT_HTML = """<!DOCTYPE html>
 </body>
 </html>"""
 
+LOOPBACK_HOST = "127.0.0.1"
+
 
 class HumanboundClient:
     """API client for Humanbound platform with OAuth authentication."""
@@ -377,6 +379,14 @@ class HumanboundClient:
         class CallbackHandler(http.server.BaseHTTPRequestHandler):
             def do_GET(self):
                 parsed = urllib.parse.urlparse(self.path)
+                if parsed.path != "/callback":
+                    auth_result["error"] = "Unexpected OAuth callback path"
+                    self.send_response(404)
+                    self.send_header("Content-type", "text/html")
+                    self.end_headers()
+                    self.wfile.write(b"Not Found")
+                    return
+
                 params = urllib.parse.parse_qs(parsed.query)
 
                 if "code" in params and params.get("state", [None])[0] == state:
@@ -403,7 +413,7 @@ class HumanboundClient:
 
         # Allow port reuse to avoid "Address already in use" errors
         socketserver.TCPServer.allow_reuse_address = True
-        server = socketserver.TCPServer(("", callback_port), CallbackHandler)
+        server = socketserver.TCPServer((LOOPBACK_HOST, callback_port), CallbackHandler)
         server.timeout = 120  # 2 minute timeout
 
         try:
@@ -1530,6 +1540,7 @@ class HumanboundClient:
             headers=headers,
             json={},
             timeout=LONG_TIMEOUT,
+            allow_redirects=False,
         )
         return self._handle_response(response)
 

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -444,7 +444,12 @@ class HumanboundClient:
             "code_verifier": code_verifier,
         }
 
-        response = requests.post(token_url, json=token_data, timeout=DEFAULT_TIMEOUT)
+        response = requests.post(
+            token_url,
+            json=token_data,
+            timeout=DEFAULT_TIMEOUT,
+            allow_redirects=False,
+        )
         if response.status_code != 200:
             raise AuthenticationError(f"Token exchange failed: {response.text}")
 
@@ -473,6 +478,7 @@ class HumanboundClient:
                     f"{self.base_url}/logout",
                     headers={"Authorization": f"Bearer {self._api_token}"},
                     timeout=DEFAULT_TIMEOUT,
+                    allow_redirects=False,
                 )
             except (requests.ConnectionError, requests.Timeout):
                 pass
@@ -526,6 +532,7 @@ class HumanboundClient:
                 f"{self.base_url}/auth",
                 headers={"Authorization": f"Bearer {self._auth0_token}"},
                 timeout=DEFAULT_TIMEOUT,
+                allow_redirects=False,
             )
         except requests.ConnectionError:
             raise AuthenticationError(
@@ -573,6 +580,7 @@ class HumanboundClient:
                 "refresh_token": refresh_token,
             },
             timeout=DEFAULT_TIMEOUT,
+            allow_redirects=False,
         )
 
         if response.status_code != 200:

--- a/humanbound_cli/commands/auth.py
+++ b/humanbound_cli/commands/auth.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from .. import telemetry
-from ..client import HumanboundClient
+from ..client import LOOPBACK_HOST, HumanboundClient
 from ..config import DEFAULT_BASE_URL
 from ..exceptions import AuthenticationError
 
@@ -125,7 +125,7 @@ def logout(revoke: bool, port: int):
                 pass
 
         socketserver.TCPServer.allow_reuse_address = True
-        server = socketserver.TCPServer(("", port), LogoutHandler)
+        server = socketserver.TCPServer((LOOPBACK_HOST, port), LogoutHandler)
         server.timeout = 30
 
         try:

--- a/tests/unit/test_oauth_callback_binding.py
+++ b/tests/unit/test_oauth_callback_binding.py
@@ -3,7 +3,7 @@
 import io
 import time
 import urllib.parse
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -50,9 +50,7 @@ def _login_with_callback(monkeypatch, callback_path: str):
         return server
 
     def serve_callback():
-        request = _FakeRequest(
-            f"GET {callback_path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
-        )
+        request = _FakeRequest(f"GET {callback_path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode())
         captured["handler"](request, ("127.0.0.1", 12345), server)
         captured["response"] = request.output.getvalue()
 
@@ -93,9 +91,7 @@ def test_login_accepts_code_and_state_on_callback_path(monkeypatch):
     captured = {}
 
     def callback_path():
-        state = urllib.parse.parse_qs(
-            urllib.parse.urlparse(captured["auth_url"]).query
-        )["state"][0]
+        state = urllib.parse.parse_qs(urllib.parse.urlparse(captured["auth_url"]).query)["state"][0]
         return f"/callback?code=code&state={state}"
 
     client = HumanboundClient(base_url="http://test.local")
@@ -166,4 +162,39 @@ def test_persist_discovery_disables_redirects(monkeypatch):
     monkeypatch.setattr("humanbound_cli.client.requests.post", post)
 
     assert client.persist_discovery("nonce") == {"persisted": 1}
+    assert post.call_args.kwargs["allow_redirects"] is False
+
+
+def test_auth_token_paths_disable_redirects(monkeypatch):
+    """Auth helpers that bypass get/post wrappers must still refuse redirects."""
+    client = HumanboundClient(base_url="http://test.local")
+    client._auth0_token = "auth0-token"
+    client._api_token = "api-token"
+
+    get = MagicMock(return_value=_response(data={"access_token": "api"}))
+    post = MagicMock(
+        return_value=_response(
+            data={"access_token": "auth0", "expires_in": 60, "refresh_token": "r"}
+        )
+    )
+    monkeypatch.setattr("humanbound_cli.client.requests.get", get)
+    monkeypatch.setattr("humanbound_cli.client.requests.post", post)
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_domain", lambda: "auth.example")
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_client_id", lambda: "client-id")
+    monkeypatch.setattr(
+        client,
+        "_load_credentials_file",
+        lambda: {"refresh_token": "refresh"},
+    )
+    monkeypatch.setattr(client, "_save_credentials", lambda *a, **k: None)
+    monkeypatch.setattr(client, "_exchange_for_api_token", lambda: None)
+
+    # Call the real exchange method once (unpatch local stub).
+    HumanboundClient._exchange_for_api_token(client)
+    assert get.call_args.kwargs["allow_redirects"] is False
+
+    client.logout(silent=True)
+    assert get.call_args.kwargs["allow_redirects"] is False
+
+    HumanboundClient._refresh_token(client)
     assert post.call_args.kwargs["allow_redirects"] is False

--- a/tests/unit/test_oauth_callback_binding.py
+++ b/tests/unit/test_oauth_callback_binding.py
@@ -1,0 +1,169 @@
+"""Security tests for OAuth callback listeners and redirects."""
+
+import io
+import time
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from humanbound_cli.client import HumanboundClient
+from humanbound_cli.exceptions import AuthenticationError
+from humanbound_cli.main import cli
+
+
+class _FakeRequest:
+    """Minimal socket-like request used to run a callback handler."""
+
+    def __init__(self, request: bytes):
+        self._input = io.BytesIO(request)
+        self.output = io.BytesIO()
+
+    def makefile(self, mode, buffering):
+        assert mode == "rb"
+        return self._input
+
+    def sendall(self, data):
+        self.output.write(data)
+
+
+def _response(status_code=200, data=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = data or {}
+    response.text = ""
+    return response
+
+
+def _login_with_callback(monkeypatch, callback_path: str):
+    """Run login through the captured handler and return its server."""
+    client = HumanboundClient(base_url="http://test.local")
+    client._exchange_for_api_token = MagicMock()
+    client._save_credentials = MagicMock()
+    captured = {}
+    server = MagicMock()
+
+    def create_server(address, handler):
+        captured["address"] = address
+        captured["handler"] = handler
+        return server
+
+    def serve_callback():
+        request = _FakeRequest(
+            f"GET {callback_path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
+        )
+        captured["handler"](request, ("127.0.0.1", 12345), server)
+        captured["response"] = request.output.getvalue()
+
+    server.handle_request.side_effect = serve_callback
+    monkeypatch.setattr("humanbound_cli.client.socketserver.TCPServer", create_server)
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_domain", lambda: "auth.example")
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_client_id", lambda: "client-id")
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_audience", lambda: "audience")
+    monkeypatch.setattr("humanbound_cli.client.webbrowser.open", lambda _: True)
+    monkeypatch.setattr(
+        "humanbound_cli.client.requests.post",
+        lambda *args, **kwargs: _response(
+            data={"access_token": "auth0-token", "expires_in": 3600, "refresh_token": "refresh"}
+        ),
+    )
+    return client, captured, server
+
+
+def test_login_binds_callback_server_to_loopback(monkeypatch):
+    client, captured, _ = _login_with_callback(monkeypatch, "/not-callback?code=code&state=state")
+
+    with pytest.raises(AuthenticationError, match="Unexpected OAuth callback path"):
+        client.login(callback_port=8099)
+
+    assert captured["address"] == ("127.0.0.1", 8099)
+
+
+def test_login_rejects_code_and_state_on_non_callback_path(monkeypatch):
+    client, captured, _ = _login_with_callback(monkeypatch, "/?code=code&state=state")
+
+    with pytest.raises(AuthenticationError, match="Unexpected OAuth callback path"):
+        client.login()
+
+    assert b"404" in captured["response"]
+
+
+def test_login_accepts_code_and_state_on_callback_path(monkeypatch):
+    captured = {}
+
+    def callback_path():
+        state = urllib.parse.parse_qs(
+            urllib.parse.urlparse(captured["auth_url"]).query
+        )["state"][0]
+        return f"/callback?code=code&state={state}"
+
+    client = HumanboundClient(base_url="http://test.local")
+    client._exchange_for_api_token = MagicMock()
+    client._save_credentials = MagicMock()
+    server = MagicMock()
+
+    def create_server(address, handler):
+        captured["address"] = address
+        captured["handler"] = handler
+        return server
+
+    def serve_callback():
+        request = _FakeRequest(
+            f"GET {callback_path()} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
+        )
+        captured["handler"](request, ("127.0.0.1", 12345), server)
+        captured["response"] = request.output.getvalue()
+
+    server.handle_request.side_effect = serve_callback
+    monkeypatch.setattr("humanbound_cli.client.socketserver.TCPServer", create_server)
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_domain", lambda: "auth.example")
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_client_id", lambda: "client-id")
+    monkeypatch.setattr("humanbound_cli.client.get_auth0_audience", lambda: "audience")
+    monkeypatch.setattr(
+        "humanbound_cli.client.webbrowser.open",
+        lambda url: captured.setdefault("auth_url", url) or True,
+    )
+    monkeypatch.setattr(
+        "humanbound_cli.client.requests.post",
+        lambda *args, **kwargs: _response(
+            data={"access_token": "auth0-token", "expires_in": 3600, "refresh_token": "refresh"}
+        ),
+    )
+
+    assert client.login() is True
+    assert captured["address"] == ("127.0.0.1", 8085)
+    assert b"200" in captured["response"]
+
+
+def test_logout_revoke_binds_callback_server_to_loopback(monkeypatch):
+    client = MagicMock()
+    server = MagicMock()
+    captured = {}
+
+    def create_server(address, handler):
+        captured["address"] = address
+        return server
+
+    monkeypatch.setattr("humanbound_cli.commands.auth.HumanboundClient", lambda: client)
+    monkeypatch.setattr("socketserver.TCPServer", create_server)
+    monkeypatch.setattr("webbrowser.open", lambda _: True)
+    monkeypatch.setattr("humanbound_cli.config.get_auth0_domain", lambda: "auth.example")
+    monkeypatch.setattr("humanbound_cli.config.get_auth0_client_id", lambda: "client-id")
+
+    result = CliRunner().invoke(cli, ["logout", "--revoke", "--port", "8099"])
+
+    assert result.exit_code == 0
+    assert captured["address"] == ("127.0.0.1", 8099)
+
+
+def test_persist_discovery_disables_redirects(monkeypatch):
+    client = HumanboundClient(base_url="http://test.local")
+    client._api_token = "api-token"
+    client._token_expires_at = time.time() + 3600
+    client._organisation_id = "org-123"
+    post = MagicMock(return_value=_response(data={"persisted": 1}))
+    monkeypatch.setattr("humanbound_cli.client.requests.post", post)
+
+    assert client.persist_discovery("nonce") == {"persisted": 1}
+    assert post.call_args.kwargs["allow_redirects"] is False


### PR DESCRIPTION
## Summary
- Login/logout OAuth callback servers bound all interfaces and accepted `code`/`state` on any path.
- Callbacks now bind `127.0.0.1`, require `/callback`, and `persist_discovery` sets `allow_redirects=False` (gap left after #80).

Distinct from #67 (XSS escape only). Not linked to open issues.

## Test plan
- [x] `pytest tests/unit/test_oauth_callback_binding.py`
- [x] `hb login` still completes via localhost callback