### PR TITLE
fix(openapi): resolve $ref parameters and request body schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local run ID now includes a short UUID suffix (`exp-{timestamp}-{uuid8}`), so
   concurrent `hb test` processes no longer overwrite each other's `_runs` slot
   or result directory.
+- **OpenAPI extraction now resolves `$ref` parameters and request body
+  schemas.** The parser previously skipped every `$ref` parameter and only read
+  inline `properties`, so component-based specs produced incomplete parameter
+  lists on the extractor. Local JSON Pointer resolution (with cycle-safe
+  `allOf` walking and depth guards) now follows `#/components/...` and Swagger 2
+  `#/parameters/...` refs. This is groundwork for consumers of `parameters` /
+  `responses`; `hb connect` today still reads only description/method/path/
+  summary from the parse result.
 
 ## [2.8.0] — 2026-07-30
 

--- a/humanbound_cli/extractors/openapi.py
+++ b/humanbound_cli/extractors/openapi.py
@@ -10,7 +10,7 @@ from typing import Any
 class OpenAPIParser:
     """Parse OpenAPI/Swagger specifications to extract bot capabilities."""
 
-    _MAX_REF_DEPTH = 32
+    _MAX_REF_DEPTH = 32  # stack-depth backstop for allOf/$ref walks (not the cycle guard)
 
     def __init__(self, spec_path: str):
         """Initialize the parser.
@@ -20,6 +20,9 @@ class OpenAPIParser:
         """
         self.spec_path = Path(spec_path).resolve()
         self._spec: dict[str, Any] | None = None
+        # Cache complete schema property walks keyed by $ref string. Truncated
+        # (cycle/depth) results must not be cached — see _walk_schema.
+        self._props_cache: dict[str, tuple[dict[str, Any], list[str]]] = {}
 
     def parse(self) -> dict[str, Any] | None:
         """Parse the OpenAPI specification.
@@ -59,6 +62,7 @@ class OpenAPIParser:
             if not isinstance(spec, dict):
                 return None
             self._spec = spec
+            self._props_cache.clear()
             return self._extract_from_spec(spec)
 
         except Exception:
@@ -110,16 +114,44 @@ class OpenAPIParser:
 
     def _schema_properties(self, schema: Any) -> tuple[dict[str, Any], list[str]]:
         """Collect properties + required names from a schema, following refs/allOf."""
+        properties, required, _ = self._walk_schema(schema)
+        return properties, required
+
+    def _walk_schema(
+        self, schema: Any, *, seen: frozenset[str] = frozenset(), depth: int = 0
+    ) -> tuple[dict[str, Any], list[str], bool]:
+        """Walk a schema, returning (properties, required, complete).
+
+        ``complete`` is False when a cycle or the depth cap truncated the walk;
+        truncated results must not be cached, since the same schema may be
+        reachable by a shorter path elsewhere in the document.
+        """
+        if depth >= self._MAX_REF_DEPTH:
+            return {}, [], False
+
+        ref_key = None
+        if isinstance(schema, dict) and isinstance(schema.get("$ref"), str):
+            ref_key = schema["$ref"]
+            if ref_key in seen:
+                return {}, [], False
+            cached = self._props_cache.get(ref_key)
+            if cached is not None:
+                return dict(cached[0]), list(cached[1]), True
+            seen = seen | {ref_key}
+
         schema = self._deref(schema)
         if not isinstance(schema, dict):
-            return {}, []
+            return {}, [], True
 
         properties: dict[str, Any] = {}
         required: list[str] = []
+        complete = True
 
-        # Shallow allOf merge — common for composed request bodies.
         for part in schema.get("allOf") or []:
-            part_props, part_req = self._schema_properties(part)
+            part_props, part_req, part_complete = self._walk_schema(
+                part, seen=seen, depth=depth + 1
+            )
+            complete = complete and part_complete
             properties.update(part_props)
             for name in part_req:
                 if name not in required:
@@ -136,7 +168,9 @@ class OpenAPIParser:
             if isinstance(name, str) and name not in required:
                 required.append(name)
 
-        return properties, required
+        if ref_key is not None and complete:
+            self._props_cache[ref_key] = (dict(properties), list(required))
+        return properties, required, complete
 
     def _param_type(self, param: dict[str, Any]) -> str:
         schema = param.get("schema")

--- a/humanbound_cli/extractors/openapi.py
+++ b/humanbound_cli/extractors/openapi.py
@@ -10,6 +10,8 @@ from typing import Any
 class OpenAPIParser:
     """Parse OpenAPI/Swagger specifications to extract bot capabilities."""
 
+    _MAX_REF_DEPTH = 32
+
     def __init__(self, spec_path: str):
         """Initialize the parser.
 
@@ -17,6 +19,7 @@ class OpenAPIParser:
             spec_path: Path to the OpenAPI spec file (JSON or YAML).
         """
         self.spec_path = Path(spec_path).resolve()
+        self._spec: dict[str, Any] | None = None
 
     def parse(self) -> dict[str, Any] | None:
         """Parse the OpenAPI specification.
@@ -53,10 +56,95 @@ class OpenAPIParser:
                     except (ImportError, Exception):
                         return None
 
+            if not isinstance(spec, dict):
+                return None
+            self._spec = spec
             return self._extract_from_spec(spec)
 
         except Exception:
             return None
+
+    def _resolve_ref(
+        self,
+        node: Any,
+        *,
+        seen: frozenset[str] | None = None,
+        depth: int = 0,
+    ) -> Any:
+        """Resolve a local JSON Pointer ``$ref`` against the loaded spec.
+
+        Only document-local refs (``#/...``) are supported. Broken refs, cycles,
+        and over-deep chains return ``None`` so extraction can skip them without
+        aborting the whole parse.
+        """
+        if not isinstance(node, dict) or "$ref" not in node:
+            return node
+        if self._spec is None or depth >= self._MAX_REF_DEPTH:
+            return None
+
+        ref = node.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            return None
+
+        seen = seen or frozenset()
+        if ref in seen:
+            return None
+
+        target: Any = self._spec
+        for part in ref[2:].split("/"):
+            part = part.replace("~1", "/").replace("~0", "~")
+            if isinstance(target, dict) and part in target:
+                target = target[part]
+            else:
+                return None
+
+        if isinstance(target, dict) and "$ref" in target:
+            return self._resolve_ref(target, seen=seen | {ref}, depth=depth + 1)
+        return target
+
+    def _deref(self, node: Any) -> Any:
+        """Return ``node`` with a single level of ``$ref`` resolved when present."""
+        if isinstance(node, dict) and "$ref" in node:
+            return self._resolve_ref(node)
+        return node
+
+    def _schema_properties(self, schema: Any) -> tuple[dict[str, Any], list[str]]:
+        """Collect properties + required names from a schema, following refs/allOf."""
+        schema = self._deref(schema)
+        if not isinstance(schema, dict):
+            return {}, []
+
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+
+        # Shallow allOf merge — common for composed request bodies.
+        for part in schema.get("allOf") or []:
+            part_props, part_req = self._schema_properties(part)
+            properties.update(part_props)
+            for name in part_req:
+                if name not in required:
+                    required.append(name)
+
+        raw_props = schema.get("properties") or {}
+        if isinstance(raw_props, dict):
+            for name, prop in raw_props.items():
+                resolved_prop = self._deref(prop)
+                if isinstance(resolved_prop, dict):
+                    properties[name] = resolved_prop
+
+        for name in schema.get("required") or []:
+            if isinstance(name, str) and name not in required:
+                required.append(name)
+
+        return properties, required
+
+    def _param_type(self, param: dict[str, Any]) -> str:
+        schema = param.get("schema")
+        if isinstance(schema, dict):
+            resolved = self._deref(schema)
+            if isinstance(resolved, dict) and resolved.get("type"):
+                return str(resolved["type"])
+        return str(param.get("type", "string"))
 
     def _extract_from_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
         """Extract relevant information from parsed spec.
@@ -138,38 +226,44 @@ class OpenAPIParser:
             if not isinstance(param, dict):
                 continue
 
-            # Handle $ref (simplified - doesn't resolve refs)
-            if "$ref" in param:
+            resolved = self._deref(param)
+            if not isinstance(resolved, dict) or "name" not in resolved:
+                # Broken or cyclic $ref — skip rather than aborting the parse.
                 continue
 
             params.append(
                 {
-                    "name": param.get("name", ""),
-                    "in": param.get("in", ""),
-                    "required": param.get("required", False),
-                    "description": param.get("description", "")[:200],
-                    "type": param.get("schema", {}).get("type", param.get("type", "string")),
+                    "name": resolved.get("name", ""),
+                    "in": resolved.get("in", ""),
+                    "required": resolved.get("required", False),
+                    "description": str(resolved.get("description", ""))[:200],
+                    "type": self._param_type(resolved),
                 }
             )
 
         # Extract request body parameters (OpenAPI 3.x)
         request_body = operation.get("requestBody", {})
-        if request_body:
+        request_body = self._deref(request_body) or {}
+        if isinstance(request_body, dict) and request_body:
             content = request_body.get("content", {})
+            if not isinstance(content, dict):
+                content = {}
             json_content = content.get("application/json", {})
+            if not isinstance(json_content, dict):
+                json_content = {}
             schema = json_content.get("schema", {})
+            properties, required = self._schema_properties(schema)
 
-            if schema.get("properties"):
-                for name, prop in schema.get("properties", {}).items():
-                    params.append(
-                        {
-                            "name": name,
-                            "in": "body",
-                            "required": name in schema.get("required", []),
-                            "description": prop.get("description", "")[:200],
-                            "type": prop.get("type", "string"),
-                        }
-                    )
+            for name, prop in properties.items():
+                params.append(
+                    {
+                        "name": name,
+                        "in": "body",
+                        "required": name in required,
+                        "description": str(prop.get("description", ""))[:200],
+                        "type": str(prop.get("type", "string")),
+                    }
+                )
 
         return params
 
@@ -185,8 +279,11 @@ class OpenAPIParser:
         responses = {}
 
         for status, response in operation.get("responses", {}).items():
-            if isinstance(response, dict):
-                responses[str(status)] = response.get("description", "")[:200]
+            if not isinstance(response, dict):
+                continue
+            resolved = self._deref(response)
+            if isinstance(resolved, dict):
+                responses[str(status)] = str(resolved.get("description", ""))[:200]
 
         return responses
 

--- a/humanbound_cli/extractors/openapi.py
+++ b/humanbound_cli/extractors/openapi.py
@@ -251,9 +251,11 @@ class OpenAPIParser:
         Returns:
             List of parameter definitions.
         """
-        params = []
+        params: list[dict] = []
+        seen: dict[tuple[str, str], int] = {}
 
-        # Combine path-level and operation-level parameters
+        # Path-level first, then operation-level — OpenAPI 3: same (name, in)
+        # at operation level overrides the path-level parameter.
         all_params = path_item.get("parameters", []) + operation.get("parameters", [])
 
         for param in all_params:
@@ -265,15 +267,19 @@ class OpenAPIParser:
                 # Broken or cyclic $ref — skip rather than aborting the parse.
                 continue
 
-            params.append(
-                {
-                    "name": resolved.get("name", ""),
-                    "in": resolved.get("in", ""),
-                    "required": resolved.get("required", False),
-                    "description": str(resolved.get("description", ""))[:200],
-                    "type": self._param_type(resolved),
-                }
-            )
+            entry = {
+                "name": resolved.get("name", ""),
+                "in": resolved.get("in", ""),
+                "required": resolved.get("required", False),
+                "description": str(resolved.get("description", ""))[:200],
+                "type": self._param_type(resolved),
+            }
+            key = (str(entry["name"]), str(entry["in"]))
+            if key in seen:
+                params[seen[key]] = entry
+            else:
+                seen[key] = len(params)
+                params.append(entry)
 
         # Extract request body parameters (OpenAPI 3.x)
         request_body = operation.get("requestBody", {})

--- a/tests/unit/test_openapi_parser.py
+++ b/tests/unit/test_openapi_parser.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""OpenAPI $ref resolution for capability extraction."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from humanbound_cli.extractors.openapi import OpenAPIParser
+
+
+def _write_spec(tmp_path: Path, spec: dict, name: str = "openapi.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    return path
+
+
+def test_inline_parameters_still_work(tmp_path):
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Inline", "version": "1.0.0"},
+        "paths": {
+            "/echo": {
+                "post": {
+                    "summary": "Echo",
+                    "parameters": [
+                        {
+                            "name": "verbose",
+                            "in": "query",
+                            "required": False,
+                            "schema": {"type": "boolean"},
+                        }
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["text"],
+                                    "properties": {
+                                        "text": {"type": "string", "description": "msg"},
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result is not None
+    params = {p["name"]: p for p in result["operations"][0]["parameters"]}
+    assert params["verbose"]["in"] == "query"
+    assert params["verbose"]["type"] == "boolean"
+    assert params["text"]["in"] == "body"
+    assert params["text"]["required"] is True
+
+
+def test_resolves_component_parameter_ref(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "RefParams", "version": "1.0.0"},
+        "components": {
+            "parameters": {
+                "IdParam": {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Resource id",
+                    "schema": {"type": "integer"},
+                }
+            }
+        },
+        "paths": {
+            "/items/{id}": {
+                "parameters": [{"$ref": "#/components/parameters/IdParam"}],
+                "get": {
+                    "operationId": "getItem",
+                    "summary": "Get item",
+                    "responses": {"200": {"description": "ok"}},
+                },
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result is not None
+    params = result["operations"][0]["parameters"]
+    assert len(params) == 1
+    assert params[0]["name"] == "id"
+    assert params[0]["in"] == "path"
+    assert params[0]["required"] is True
+    assert params[0]["type"] == "integer"
+    assert params[0]["description"] == "Resource id"
+
+
+def test_resolves_request_body_schema_ref(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "RefBody", "version": "1.0.0"},
+        "components": {
+            "schemas": {
+                "Message": {
+                    "type": "object",
+                    "required": ["content"],
+                    "properties": {
+                        "content": {"type": "string", "description": "user text"},
+                        "temperature": {"type": "number"},
+                    },
+                }
+            }
+        },
+        "paths": {
+            "/chat": {
+                "post": {
+                    "summary": "Chat",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Message"}
+                            }
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    params = {p["name"]: p for p in result["operations"][0]["parameters"]}
+    assert params["content"]["in"] == "body"
+    assert params["content"]["required"] is True
+    assert params["content"]["type"] == "string"
+    assert params["temperature"]["type"] == "number"
+
+
+def test_resolves_nested_schema_property_ref(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Nested", "version": "1.0.0"},
+        "components": {
+            "schemas": {
+                "Prompt": {"type": "string", "description": "prompt text"},
+                "Request": {
+                    "type": "object",
+                    "properties": {
+                        "prompt": {"$ref": "#/components/schemas/Prompt"},
+                    },
+                },
+            }
+        },
+        "paths": {
+            "/run": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Request"}
+                            }
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    params = result["operations"][0]["parameters"]
+    assert params[0]["name"] == "prompt"
+    assert params[0]["type"] == "string"
+    assert params[0]["description"] == "prompt text"
+
+
+def test_allof_merges_properties(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "AllOf", "version": "1.0.0"},
+        "components": {
+            "schemas": {
+                "Base": {
+                    "type": "object",
+                    "properties": {"role": {"type": "string"}},
+                    "required": ["role"],
+                },
+                "Ext": {
+                    "allOf": [
+                        {"$ref": "#/components/schemas/Base"},
+                        {
+                            "type": "object",
+                            "properties": {"content": {"type": "string"}},
+                        },
+                    ]
+                },
+            }
+        },
+        "paths": {
+            "/x": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/Ext"}
+                            }
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    names = {p["name"] for p in result["operations"][0]["parameters"]}
+    assert names == {"role", "content"}
+
+
+def test_cyclic_ref_does_not_loop(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Cycle", "version": "1.0.0"},
+        "components": {
+            "parameters": {
+                "A": {"$ref": "#/components/parameters/B"},
+                "B": {"$ref": "#/components/parameters/A"},
+            }
+        },
+        "paths": {
+            "/loop": {
+                "get": {
+                    "parameters": [{"$ref": "#/components/parameters/A"}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result is not None
+    # Cycle is skipped, not fatal.
+    assert result["operations"][0]["parameters"] == []
+
+
+def test_broken_ref_is_skipped(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Broken", "version": "1.0.0"},
+        "paths": {
+            "/x": {
+                "get": {
+                    "parameters": [{"$ref": "#/components/parameters/Missing"}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result["operations"][0]["parameters"] == []
+
+
+def test_swagger2_parameter_ref(tmp_path):
+    spec = {
+        "swagger": "2.0",
+        "info": {"title": "Swagger", "version": "1.0.0"},
+        "host": "api.example.com",
+        "basePath": "/v1",
+        "schemes": ["https"],
+        "parameters": {
+            "Q": {
+                "name": "q",
+                "in": "query",
+                "type": "string",
+                "required": True,
+            }
+        },
+        "paths": {
+            "/search": {
+                "get": {
+                    "summary": "Search",
+                    "parameters": [{"$ref": "#/parameters/Q"}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result["servers"] == ["https://api.example.com/v1"]
+    params = result["operations"][0]["parameters"]
+    assert params[0]["name"] == "q"
+    assert params[0]["type"] == "string"
+
+
+def test_resolves_response_ref_description(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Resp", "version": "1.0.0"},
+        "components": {
+            "responses": {
+                "NotFound": {"description": "Missing resource"},
+            }
+        },
+        "paths": {
+            "/x": {
+                "get": {
+                    "responses": {
+                        "404": {"$ref": "#/components/responses/NotFound"},
+                    }
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result["operations"][0]["responses"]["404"] == "Missing resource"
+
+
+def test_to_intents_includes_ref_backed_operations(tmp_path):
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Intents", "version": "1.0.0"},
+        "components": {
+            "parameters": {
+                "IdParam": {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            }
+        },
+        "paths": {
+            "/agents/{id}": {
+                "get": {
+                    "summary": "Fetch agent",
+                    "parameters": [{"$ref": "#/components/parameters/IdParam"}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    intents = OpenAPIParser(str(_write_spec(tmp_path, spec))).to_intents()
+    assert "Fetch agent" in intents["permitted"]
+
+
+@pytest.mark.skipif(
+    __import__("importlib").util.find_spec("yaml") is None,
+    reason="PyYAML not installed",
+)
+def test_yaml_spec_with_refs(tmp_path):
+    import yaml
+
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "YAML", "version": "1.0.0"},
+        "components": {
+            "parameters": {
+                "Token": {
+                    "name": "token",
+                    "in": "header",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            }
+        },
+        "paths": {
+            "/secure": {
+                "get": {
+                    "parameters": [{"$ref": "#/components/parameters/Token"}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    path = tmp_path / "openapi.yaml"
+    path.write_text(yaml.safe_dump(spec), encoding="utf-8")
+    result = OpenAPIParser(str(path)).parse()
+    assert result["operations"][0]["parameters"][0]["name"] == "token"

--- a/tests/unit/test_openapi_parser.py
+++ b/tests/unit/test_openapi_parser.py
@@ -118,9 +118,7 @@ def test_resolves_request_body_schema_ref(tmp_path):
                     "summary": "Chat",
                     "requestBody": {
                         "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Message"}
-                            }
+                            "application/json": {"schema": {"$ref": "#/components/schemas/Message"}}
                         }
                     },
                     "responses": {"200": {"description": "ok"}},
@@ -156,9 +154,7 @@ def test_resolves_nested_schema_property_ref(tmp_path):
                 "post": {
                     "requestBody": {
                         "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Request"}
-                            }
+                            "application/json": {"schema": {"$ref": "#/components/schemas/Request"}}
                         }
                     },
                     "responses": {"200": {"description": "ok"}},
@@ -200,9 +196,7 @@ def test_allof_merges_properties(tmp_path):
                 "post": {
                     "requestBody": {
                         "content": {
-                            "application/json": {
-                                "schema": {"$ref": "#/components/schemas/Ext"}
-                            }
+                            "application/json": {"schema": {"$ref": "#/components/schemas/Ext"}}
                         }
                     },
                     "responses": {"200": {"description": "ok"}},
@@ -213,6 +207,84 @@ def test_allof_merges_properties(tmp_path):
     result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
     names = {p["name"] for p in result["operations"][0]["parameters"]}
     assert names == {"role", "content"}
+
+
+def test_cyclic_allof_does_not_discard_spec(tmp_path):
+    """Mutually-referential allOf must not RecursionError / return None from parse()."""
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "CycleAllOf", "version": "1.0.0"},
+        "components": {
+            "schemas": {
+                "A": {
+                    "allOf": [{"$ref": "#/components/schemas/B"}],
+                    "properties": {"a": {"type": "string"}},
+                },
+                "B": {
+                    "allOf": [{"$ref": "#/components/schemas/A"}],
+                    "properties": {"b": {"type": "string"}},
+                },
+            }
+        },
+        "paths": {
+            "/x": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/A"}}
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    assert result is not None
+    names = {p["name"] for p in result["operations"][0]["parameters"]}
+    assert names == {"a", "b"}
+
+
+def test_allof_fanout_is_cached_not_exponential(tmp_path):
+    """Sibling allOf branches that re-enter the same $ref must not explode runtime."""
+    schemas = {
+        f"N{i}": {
+            "allOf": [
+                {"$ref": f"#/components/schemas/N{i + 1}"},
+                {"$ref": f"#/components/schemas/N{i + 1}"},
+            ],
+            "properties": {f"p{i}": {"type": "string"}},
+        }
+        for i in range(20)
+    }
+    schemas["N20"] = {"properties": {"leaf": {"type": "string"}}}
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "FanOut", "version": "1.0.0"},
+        "components": {"schemas": schemas},
+        "paths": {
+            "/x": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/N0"}}
+                        }
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    import time
+
+    started = time.perf_counter()
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    elapsed = time.perf_counter() - started
+    assert result is not None
+    assert elapsed < 1.0, f"fan-out walk too slow: {elapsed:.3f}s"
+    names = {p["name"] for p in result["operations"][0]["parameters"]}
+    assert "leaf" in names
+    assert "p0" in names
 
 
 def test_cyclic_ref_does_not_loop(tmp_path):

--- a/tests/unit/test_openapi_parser.py
+++ b/tests/unit/test_openapi_parser.py
@@ -245,6 +245,48 @@ def test_cyclic_allof_does_not_discard_spec(tmp_path):
     assert names == {"a", "b"}
 
 
+def test_operation_parameter_overrides_path_level_same_name_in(tmp_path):
+    """OpenAPI 3: operation-level (name, in) wins over path-level."""
+    spec = {
+        "openapi": "3.0.3",
+        "info": {"title": "Override", "version": "1.0.0"},
+        "components": {
+            "parameters": {
+                "SharedId": {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "description": "shared",
+                    "schema": {"type": "integer"},
+                }
+            }
+        },
+        "paths": {
+            "/items/{id}": {
+                "parameters": [{"$ref": "#/components/parameters/SharedId"}],
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": True,
+                            "description": "overridden",
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            }
+        },
+    }
+    result = OpenAPIParser(str(_write_spec(tmp_path, spec))).parse()
+    params = result["operations"][0]["parameters"]
+    assert len(params) == 1
+    assert params[0]["name"] == "id"
+    assert params[0]["type"] == "string"
+    assert params[0]["description"] == "overridden"
+
+
 def test_allof_fanout_is_cached_not_exponential(tmp_path):
     """Sibling allOf branches that re-enter the same $ref must not explode runtime."""
     schemas = {


### PR DESCRIPTION
## Summary
- OpenAPI extraction skipped `$ref` parameters and only read inline request schemas, so component-based specs produced empty capability lists.
- Adds a cycle-safe JSON Pointer resolver for OpenAPI 3 / Swagger 2 refs during extraction.

Not tied to any existing issue/PR.

## Test plan
- [x] `pytest tests/unit/test_openapi_parser.py` (11 passed)
- [x] `hb connect` against a component-heavy OpenAPI file and confirm parameters appear