### PR TITLE
fix(engine): keep partial results when local runs fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Agentic category-worker failures no longer report a completed scan.**
-  Exceptions raised by an OWASP Agentic category worker are now surfaced through
-  the engine error callback and mark the run `Failed`; local runs preserve that
-  failure status while saving completed partial results.
+  (#107, thanks @Ayush7614). Exceptions raised by an OWASP Agentic category
+  worker are now surfaced through the engine error callback and mark the run
+  `Failed`; local runs preserve that failure status while saving completed
+  partial results. Note for CI users: runs that previously (and wrongly)
+  exited `0` on a worker crash now exit `2`, per the documented exit-code
+  contract.
+- **`hb test` no longer claims "no results produced" when a failed run saved
+  partial results** — the exit message now points to `hb logs` instead.
+- **A crash in any local orchestrator keeps completed conversations.** The
+  local runner's generic failure path now saves partial results the same way
+  an orchestrator-reported failure does, so `owasp_single_turn` and
+  `behavioral_qa` crashes no longer discard finished work.
 
 ### Security
 - **Local secret files are written atomically at `0600`** (#67, thanks

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -871,6 +871,8 @@ def _resolve_exit(result: TestResult, final_status: str, fail_on: str) -> tuple[
     severity and sees nothing in either case.
     """
     if final_status == "Failed":
+        if (result.stats or {}).get("total", 0):
+            return EXIT_RUN_FAILED, "Run failed — partial results saved. See `hb logs`."
         return EXIT_RUN_FAILED, "Run failed — no results produced."
     if _all_errored(result.stats):
         return EXIT_RUN_FAILED, "No conversations completed — treating this run as a failure."

--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -145,6 +145,17 @@ class _LocalRun:
             # DEBUG level so `--debug` users can still see the full stack.
             logger.error(f"Local test failed: {e}")
             logger.debug(traceback.format_exc())
+            # Save partial results best-effort — never mask the original failure.
+            if self.logs:
+                try:
+                    self.results = presenter_run(
+                        None,
+                        self.logs,
+                        test_category=self.config.test_category,
+                    )
+                    self._save_results()
+                except Exception:
+                    logger.debug("Could not save partial results", exc_info=True)
 
     def _save_results(self):
         """Write meta.json + logs.jsonl to .humanbound/results/

--- a/tests/unit/test_errored_run_reporting.py
+++ b/tests/unit/test_errored_run_reporting.py
@@ -74,12 +74,24 @@ _HIGH_INSIGHT = [{"result": "fail", "severity": "high", "explanation": "x"}]
         (_ALL_ERRORED, None, "Finished", "any", EXIT_RUN_FAILED),  # run failure wins
         (_CLEAN, _HIGH_INSIGHT, "Failed", "high", EXIT_RUN_FAILED),  # Failed wins over fail-on
         ({"total": 5, "pass": 2, "fail": 0, "error": 3}, None, "Finished", "", EXIT_OK),  # partial
+        ({"total": 2, "pass": 1, "fail": 1, "error": 0}, None, "Failed", "", EXIT_RUN_FAILED),
     ],
 )
 def test_resolve_exit_policy(stats, insights, final_status, fail_on, expected):
     code, reason = _resolve_exit(_result(stats, insights), final_status, fail_on)
     assert code == expected
     assert (reason is None) is (code == EXIT_OK)
+
+
+def test_failed_run_message_reflects_partial_results():
+    """A Failed run that saved partial results must not claim none were produced."""
+    _, with_results = _resolve_exit(
+        _result({"total": 2, "pass": 1, "fail": 1, "error": 0}), "Failed", ""
+    )
+    assert "partial results" in with_results
+
+    _, without_results = _resolve_exit(_result({}), "Failed", "")
+    assert without_results == "Run failed — no results produced."
 
 
 # ────────────────────────────────────────────────────────────────

--- a/tests/unit/test_local_runner_partial_results.py
+++ b/tests/unit/test_local_runner_partial_results.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Failed local runs keep completed conversations as saved partial results,
+whether the orchestrator reported the failure via on_complete("Failed") or
+raised out of orchestrator_run entirely."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from humanbound_cli.engine.local_runner import _LocalRun
+from humanbound_cli.engine.runner import TestConfig as _TestConfig
+from humanbound_cli.engine.schemas import LogsAnonymous, Status
+
+
+def _log(i: int, result: str = "pass") -> dict:
+    return LogsAnonymous(
+        thread_id=f"t{i}",
+        conversation=[{"u": "hi", "a": "there"}],
+        prompt="hi",
+        response="there",
+        result=result,
+        gen_category="prompt_injection",
+        fail_category="",
+        explanation="",
+        severity=0,
+        confidence=90,
+        exec_t=1,
+    ).model_dump()
+
+
+def _execute(orchestrator_run_side_effect):
+    orchestrator = MagicMock()
+    orchestrator.orchestrator_generate.return_value = {}
+    orchestrator.orchestrator_run.side_effect = orchestrator_run_side_effect
+    run = _LocalRun(
+        "exp-partial",
+        _TestConfig(test_category="owasp_agentic", endpoint={}),
+    )
+
+    with (
+        patch("humanbound_cli.engine.local_runner._resolve_provider", return_value={}),
+        patch("humanbound_cli.engine.llm.get_llm_pinger", return_value=None),
+        patch("humanbound_cli.engine.scope.resolve", return_value={}),
+        patch("humanbound_cli.engine.local_runner._load_orchestrator", return_value=orchestrator),
+        patch("humanbound_cli.engine.local_runner.presenter_run") as presenter,
+        patch.object(run, "_save_results") as save_results,
+    ):
+        run.execute()
+
+    return run, presenter, save_results
+
+
+def test_orchestrator_reported_failure_saves_partial_results():
+    def side_effect(**kwargs):
+        kwargs["callbacks"].on_logs([_log(1), _log(2, "fail")])
+        kwargs["callbacks"].on_complete(Status.Failed.value)
+
+    run, presenter, save_results = _execute(side_effect)
+
+    assert run.status == Status.Failed.value
+    presenter.assert_called_once()
+    save_results.assert_called_once()
+
+
+def test_orchestrator_crash_saves_partial_results():
+    def side_effect(**kwargs):
+        kwargs["callbacks"].on_logs([_log(1), _log(2, "fail")])
+        raise ValueError("model provider missing api key")
+
+    run, presenter, save_results = _execute(side_effect)
+
+    assert run.status == Status.Failed.value
+    assert run.error == "model provider missing api key"
+    presenter.assert_called_once()
+    save_results.assert_called_once()
+
+
+def test_orchestrator_crash_without_logs_saves_nothing():
+    run, presenter, save_results = _execute(ValueError("boom before any conversation"))
+
+    assert run.status == Status.Failed.value
+    presenter.assert_not_called()
+    save_results.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #107, which preserved `Failed` status for agentic runs and saved
partial results when the orchestrator *reported* a failure. This closes the two
gaps around it:

- **Crashes now keep finished work too.** A local run that raises out of
  `orchestrator_run` (`owasp_single_turn`, `behavioral_qa`, or any custom
  orchestrator) previously set `Failed` and discarded completed conversations.
  The generic failure path now saves them the same way — best-effort and
  wrapped, so a presenter/write error can never replace the original failure
  status.
- **The exit message tells the truth.** A `Failed` run with saved partial
  results now points to `hb logs` instead of claiming "no results produced".
  Exit codes are unchanged (still `2` for both cases, per the documented
  contract), so CI gates are unaffected.

## Test plan

- 5 new tests: exit-message split in `test_errored_run_reporting.py`; both
  partial-save paths (orchestrator-reported and crash) plus the no-logs case in
  `test_local_runner_partial_results.py`.
- Verified end-to-end against an offline mock-LLM/mock-bot sandbox: happy path
  unchanged (`Finished`, exit 0); crash without logs (exit 2, "no results
  produced"); crash with 82 completed conversations (exit 2, partial-results
  message, `meta.json` readable by `hb logs` / `hb posture`).

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` — not needed: docs document exit
      *codes* (unchanged), not message text
- [x] All commits are signed off (`git commit -s`)

## Linked issue(s)

Follow-up to #107 (no issue).