### PR TITLE
fix(engine): judge agentic category failures after the pool joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local runner's generic failure path now saves partial results the same way
   an orchestrator-reported failure does, so `owasp_single_turn` and
   `behavioral_qa` crashes no longer discard finished work.
+- **Agentic category failures are judged after the worker pool joins, not on
+  a per-future timeout.** The pool shutdown always waited for every started
+  worker, so the old 3-hour `future.result` timeout could only misreport a
+  slow-but-successful category as failed — never actually bound the run. A
+  worker crash also no longer prints its traceback twice on stderr; the full
+  trace still reaches the error callback and DEBUG logging.
 
 ### Security
 - **Local secret files are written atomically at `0600`** (#67, thanks

--- a/humanbound_cli/engine/orchestrators/owasp_agentic/orchestrator.py
+++ b/humanbound_cli/engine/orchestrators/owasp_agentic/orchestrator.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import time
 import traceback
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 
 from ...bot import Bot, Telemetry
 from ...callbacks import EngineCallbacks, log_buffer_len
@@ -21,7 +21,6 @@ from .judge import Judge
 logger = logging.getLogger("humanbound.engine.orchestrator")
 
 # Constants
-EXPERIMENT_THREAD_TIMEOUT = 10800  # 3 hours
 INIT_LOGS_BUFFER_LENGTH = 5
 
 LOGS_BUFFER_LENGTH = 20  # number of logs to buffer before sending them in a single request
@@ -398,32 +397,38 @@ def orchestrator_run(
             )
             futures[future] = test_sub_category
 
-        category_failures = []
-        for future in futures:
-            try:
-                if callbacks.is_terminated():
+        pending = set(futures)
+        while pending:
+            _done, pending = wait(pending, timeout=1.0)
+            if callbacks.is_terminated():
+                for future in pending:
                     future.cancel()
-                    continue
-                future.result(timeout=EXPERIMENT_THREAD_TIMEOUT)
-            except Exception as e:
-                if callbacks.is_terminated():
-                    continue
+                break
 
-                test_sub_category = futures[future]
-                category_failures.append((test_sub_category, e))
-                logger.exception(
-                    "OWASP Agentic category worker failed: %s",
-                    test_sub_category,
-                )
-                callbacks.on_error(
-                    e.__class__.__name__,
-                    {
-                        "where": "OWASP Agentic :: Category worker",
-                        "category": test_sub_category,
-                        "e": str(e),
-                        "trace": traceback.format_exc(),
-                    },
-                )
+    # Pool has joined — every started worker finished; judge failures now.
+    category_failures = []
+    if not callbacks.is_terminated():
+        for future, test_sub_category in futures.items():
+            if future.cancelled():
+                continue
+            e = future.exception()
+            if e is None:
+                continue
+            category_failures.append((test_sub_category, e))
+            logger.debug(
+                "OWASP Agentic category worker failed: %s",
+                test_sub_category,
+                exc_info=e,
+            )
+            callbacks.on_error(
+                e.__class__.__name__,
+                {
+                    "where": "OWASP Agentic :: Category worker",
+                    "category": test_sub_category,
+                    "e": str(e),
+                    "trace": "".join(traceback.format_exception(e)),
+                },
+            )
 
     # Signal completion via callback
     if not callbacks.is_terminated():

--- a/tests/unit/test_agentic_category_failures.py
+++ b/tests/unit/test_agentic_category_failures.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import importlib
+import time
+from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
 from humanbound_cli.engine.callbacks import EngineCallbacks
@@ -20,17 +22,13 @@ EXPERIMENT = {
 }
 
 
-class _Future:
-    def __init__(self, error: Exception | None = None):
-        self.error = error
-        self.cancelled = False
-
-    def result(self, timeout=None):
-        if self.error:
-            raise self.error
-
-    def cancel(self):
-        self.cancelled = True
+def _future(error: Exception | None = None) -> Future:
+    f = Future()
+    if error:
+        f.set_exception(error)
+    else:
+        f.set_result(None)
+    return f
 
 
 class _Executor:
@@ -71,7 +69,7 @@ def test_category_worker_failure_marks_agentic_run_failed_and_reports_error():
         on_error=lambda title, details: errors.append((title, details)),
     )
 
-    _run_with_futures([_Future(), _Future(RuntimeError("second category failed"))], callbacks)
+    _run_with_futures([_future(), _future(RuntimeError("second category failed"))], callbacks)
 
     assert completed == [Status.Failed.value]
     assert len(errors) == 1
@@ -91,10 +89,45 @@ def test_all_category_workers_complete_marks_agentic_run_finished():
         on_error=lambda title, details: errors.append((title, details)),
     )
 
-    _run_with_futures([_Future(), _Future()], callbacks)
+    _run_with_futures([_future(), _future()], callbacks)
 
     assert completed == [Status.Finished.value]
     assert errors == []
+
+
+def test_slow_category_worker_is_not_marked_failed():
+    """A worker that outlives the harvest poll interval but succeeds must not
+    fail the run — failures are judged after the pool joins, not on a timeout."""
+    completed = []
+    errors = []
+    logs = []
+    callbacks = EngineCallbacks(
+        on_logs=logs.extend,
+        on_complete=completed.append,
+        on_error=lambda title, details: errors.append((title, details)),
+        flush_every_log=True,
+    )
+
+    def slow_worker(*args, **kwargs):
+        time.sleep(1.5)
+        callbacks.deliver_logs([{"category": "slow"}])
+
+    with (
+        patch.object(ORCH, "Bot", return_value=object()),
+        patch.object(ORCH, "__do_thread_run", slow_worker),
+    ):
+        ORCH.orchestrator_run(
+            organisation_id="org",
+            model_provider={},
+            experiment=EXPERIMENT,
+            prompts={"slow": []},
+            few_shots_model=None,
+            callbacks=callbacks,
+        )
+
+    assert completed == [Status.Finished.value]
+    assert errors == []
+    assert logs == [{"category": "slow"}]
 
 
 def test_local_run_preserves_failed_status_reported_by_orchestrator():


### PR DESCRIPTION
## Summary

Second follow-up to #107, addressing the two non-blocking review notes on the
category-worker harvest loop:

- **A slow-but-successful category no longer fails the run.** The pool's
  `shutdown(wait=True)` always waited for every started worker, so the 3-hour
  `future.result` timeout could only *misreport* — never actually bound the
  run. Failures are now judged via `future.exception()` after the pool joins;
  the unused timeout constant is removed. Termination still cancels
  not-yet-started categories promptly (1s `wait()` poll).
- **Worker crashes print their traceback once, not twice.** `logger.exception`
  dropped to DEBUG; the full trace still reaches the engine error callback.

## Test plan

- New regression test: a worker outliving the harvest poll interval but
  succeeding → run `Finished`, logs delivered, no errors.
- Existing #107 tests updated to real `concurrent.futures.Future` objects
  (required by `wait()`); all assertions unchanged.
- Verified live against the offline mock-LLM/mock-bot sandbox: injected worker
  crash alongside 82 real conversations → `Failed`, exit 2, partial results
  saved, exactly one stderr report (previously two full tracebacks).

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` — not needed: internal engine behavior
- [x] All commits are signed off (`git commit -s`)

## Linked issue(s)

Follow-up to #107 (no issue).