### PR TITLE
fix(cli): export local guardrails insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`hb guardrails` now exports rules from local test results.** Local runs
+  store insights beneath `results.insights`, but the exporter only read the
+  legacy top-level key and consequently emitted an empty ruleset. The exporter
+  now reads the current schema while retaining the legacy fallback (#102).
 - **Agentic category-worker failures no longer report a completed scan.**
   (#107, thanks @Ayush7614). Exceptions raised by an OWASP Agentic category
   worker are now surfaced through the engine error callback and mark the run

--- a/humanbound_cli/commands/guardrails.py
+++ b/humanbound_cli/commands/guardrails.py
@@ -143,7 +143,8 @@ def _local_guardrails(output, output_format, vendor):
         raise SystemExit(1)
 
     meta = json.loads(meta_file.read_text())
-    insights = meta.get("insights", [])
+    results = meta.get("results", {})
+    insights = results.get("insights", meta.get("insights", []))
 
     # Read logs for pattern extraction
     logs = []

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -5,6 +5,7 @@ so we patch `get_runner` and wire in a mock client via `platform_runner`.
 """
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -16,6 +17,7 @@ from .conftest import (
     MOCK_GUARDRAILS,
     assert_exit_error,
     assert_exit_ok,
+    local_runner,
     platform_runner,
 )
 
@@ -126,6 +128,75 @@ class TestHappyPath:
             params={"include_reasoning": "true"},
             include_project=True,
         )
+
+
+class TestLocalGuardrails:
+    @patch(RUNNER_PATCH)
+    def test_exports_failed_insights_from_results_metadata(self, mock_get_runner):
+        mock_get_runner.return_value = local_runner()
+
+        with runner.isolated_filesystem():
+            experiment_dir = Path(".humanbound/results/20260803-guardrails")
+            experiment_dir.mkdir(parents=True)
+            (experiment_dir / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "results": {
+                            "insights": [
+                                {
+                                    "result": "fail",
+                                    "category": "prompt_injection",
+                                    "explanation": "The bot followed an injected instruction.",
+                                    "severity": "high",
+                                }
+                            ]
+                        }
+                    }
+                )
+            )
+
+            result = runner.invoke(cli, ["guardrails"])
+
+        assert_exit_ok(result)
+        data = json.loads(result.output)
+        assert data["metadata"]["total_rules"] == 1
+        assert data["rules"] == [
+            {
+                "id": "gr-001",
+                "threat_class": "prompt_injection",
+                "pattern": "The bot followed an injected instruction.",
+                "action": "block",
+                "severity": "high",
+                "source": "20260803-guardrails",
+            }
+        ]
+
+    @patch(RUNNER_PATCH)
+    def test_uses_top_level_insights_as_legacy_fallback(self, mock_get_runner):
+        mock_get_runner.return_value = local_runner()
+
+        with runner.isolated_filesystem():
+            experiment_dir = Path(".humanbound/results/legacy-result")
+            experiment_dir.mkdir(parents=True)
+            (experiment_dir / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "insights": [
+                            {
+                                "result": "fail",
+                                "category": "legacy",
+                            }
+                        ]
+                    }
+                )
+            )
+
+            result = runner.invoke(cli, ["guardrails"])
+
+        assert_exit_ok(result)
+        data = json.loads(result.output)
+        assert data["metadata"]["total_rules"] == 1
+        assert data["rules"][0]["threat_class"] == "legacy"
 
 
 class TestErrorCases:


### PR DESCRIPTION
## Summary

Fixes #102 by reading local experiment insights from the current `results.insights` schema. The legacy top-level `insights` field remains supported for older result files.

## Root cause

`LocalTestRunner` writes `ExperimentMeta.results.insights`, while `hb guardrails` only read `meta["insights"]`. As a result, local guardrail exports always produced an empty rules list despite failed insights being present.

## Validation

- Added CLI-level regression coverage for the current local metadata schema.
- Added compatibility coverage for legacy top-level insights.
- `pytest tests/unit/test_guardrails.py -q`
- `ruff check humanbound_cli/commands/guardrails.py tests/unit/test_guardrails.py`
