### PR TITLE
fix(mcp): return structured errors for all failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   store insights beneath `results.insights`, but the exporter only read the
   legacy top-level key and consequently emitted an empty ruleset. The exporter
   now reads the current schema while retaining the legacy fallback (#102).
+- **Network failures now surface as a clean `APIError` everywhere** (#68,
+  thanks @JChario for the report and the original fix). The client called
+  `requests` without wrapping transport errors, so a dropped connection or
+  timeout escaped as a raw requests exception — MCP tools returned FastMCP's
+  raw "Error executing tool …" text instead of their structured
+  `{"error": …}` envelope, and the message carried urllib3 internals. The
+  client now converts transport failures to `APIError` at the source (CLI
+  commands and all MCP tools handle it uniformly), and every MCP tool
+  additionally falls back to the structured envelope for any unexpected
+  exception.
+- **`pip install humanbound[mcp]` works again.** mcp 2.0.0 (2026-07-28)
+  removed `mcp.server.fastmcp`, so a fresh install broke `hb mcp` at import;
+  the extra now pins `mcp>=1.2.0,<2`.
 - **Agentic category-worker failures no longer report a completed scan.**
   (#107, thanks @Ayush7614). Exceptions raised by an OWASP Agentic category
   worker are now surfaced through the engine error callback and mark the run

--- a/humanbound_cli/client.py
+++ b/humanbound_cli/client.py
@@ -762,6 +762,26 @@ class HumanboundClient:
 
         return data
 
+    def _send(self, request_fn, endpoint: str, **kwargs) -> Any:
+        """Send a request and normalize transport failures.
+
+        Network errors (connection refused, DNS, timeout) surface as APIError
+        so every caller — CLI commands and MCP tools alike — handles them
+        through the HumanboundError hierarchy instead of a raw requests
+        exception.
+        """
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        try:
+            response = request_fn(url, allow_redirects=False, **kwargs)
+        except requests.Timeout as e:
+            raise APIError(f"Connection to {self.base_url} timed out.") from e
+        except requests.RequestException as e:
+            raise APIError(
+                f"Could not connect to {self.base_url} ({e.__class__.__name__}). "
+                "Is the server reachable?"
+            ) from e
+        return self._handle_response(response)
+
     def get(
         self,
         endpoint: str,
@@ -788,14 +808,13 @@ class HumanboundClient:
         headers = self._get_headers(include_org, include_project)
         if extra_headers:
             headers.update(extra_headers)
-        response = requests.get(
-            f"{self.base_url}/{endpoint.lstrip('/')}",
+        return self._send(
+            requests.get,
+            endpoint,
             headers=headers,
             params=params,
             timeout=timeout,
-            allow_redirects=False,
         )
-        return self._handle_response(response)
 
     def post(
         self,
@@ -818,14 +837,13 @@ class HumanboundClient:
             Parsed JSON response.
         """
         self._ensure_authenticated()
-        response = requests.post(
-            f"{self.base_url}/{endpoint.lstrip('/')}",
+        return self._send(
+            requests.post,
+            endpoint,
             headers=self._get_headers(include_org, include_project),
             json=data,
             timeout=timeout,
-            allow_redirects=False,
         )
-        return self._handle_response(response)
 
     def put(
         self,
@@ -848,14 +866,13 @@ class HumanboundClient:
             Parsed JSON response.
         """
         self._ensure_authenticated()
-        response = requests.put(
-            f"{self.base_url}/{endpoint.lstrip('/')}",
+        return self._send(
+            requests.put,
+            endpoint,
             headers=self._get_headers(include_org, include_project),
             json=data,
             timeout=timeout,
-            allow_redirects=False,
         )
-        return self._handle_response(response)
 
     def delete(
         self,
@@ -876,13 +893,12 @@ class HumanboundClient:
             Parsed JSON response.
         """
         self._ensure_authenticated()
-        response = requests.delete(
-            f"{self.base_url}/{endpoint.lstrip('/')}",
+        return self._send(
+            requests.delete,
+            endpoint,
             headers=self._get_headers(include_org, include_project),
             timeout=timeout,
-            allow_redirects=False,
         )
-        return self._handle_response(response)
 
     # -------------------------------------------------------------------------
     # Convenience Methods

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -17,7 +17,6 @@ import sys
 from mcp.server.fastmcp import FastMCP
 
 from .client import HumanboundClient
-from .exceptions import HumanboundError
 
 # ---------------------------------------------------------------------------
 # Logging — everything to stderr so stdout stays clean for JSON-RPC
@@ -110,7 +109,7 @@ def hb_whoami() -> str:
                 "base_url": client.base_url,
             }
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -120,7 +119,7 @@ def hb_list_organisations() -> str:
     try:
         client = _get_client()
         return _ok(client.list_organisations())
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -141,7 +140,7 @@ def hb_set_organisation(organisation_id: str) -> str:
         return _ok(
             {"organisation_id": organisation_id, "message": "Organisation set successfully."}
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -160,7 +159,7 @@ def hb_set_project(project_id: str) -> str:
         client = _get_client()
         client.set_project(project_id)
         return _ok({"project_id": project_id, "message": "Project set successfully."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -180,7 +179,7 @@ def hb_list_projects(page: int = 1, size: int = 50) -> str:
     try:
         client = _get_client()
         return _ok(client.list_projects(page=page, size=size))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -194,7 +193,7 @@ def hb_get_project(project_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get(f"projects/{project_id}", include_project=True))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -217,7 +216,7 @@ def hb_update_project(
         if description is not None:
             data["description"] = description
         return _ok(client.update_project(project_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -232,7 +231,7 @@ def hb_delete_project(project_id: str) -> str:
         client = _get_client()
         client.delete_project(project_id)
         return _ok({"message": f"Project {project_id} deleted."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -254,7 +253,7 @@ def hb_create_project(name: str, description: str | None = None) -> str:
         if description is not None:
             data["description"] = description
         return _ok(client.post("projects", data=data, include_project=False))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -274,7 +273,7 @@ def hb_list_experiments(page: int = 1, size: int = 50) -> str:
     try:
         client = _get_client()
         return _ok(client.list_experiments(page=page, size=size))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -288,7 +287,7 @@ def hb_get_experiment(experiment_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get_experiment(experiment_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -308,7 +307,7 @@ def hb_get_experiment_status(experiment_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get_experiment_status(experiment_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -330,7 +329,7 @@ def hb_get_experiment_logs(
     try:
         client = _get_client()
         return _ok(client.get_experiment_logs(experiment_id, page=page, size=size, result=result))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -344,7 +343,7 @@ def hb_terminate_experiment(experiment_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.terminate_experiment(experiment_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -359,7 +358,7 @@ def hb_delete_experiment(experiment_id: str) -> str:
         client = _get_client()
         client.delete_experiment(experiment_id)
         return _ok({"message": f"Experiment {experiment_id} deleted."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -450,7 +449,7 @@ def hb_run_test(
 
         result = client.post("experiments", data=data, include_project=True)
         return _ok(result)
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -493,7 +492,7 @@ def hb_get_project_logs(
                 last=last,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -508,7 +507,7 @@ def hb_list_providers() -> str:
     try:
         client = _get_client()
         return _ok(client.list_providers())
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -537,7 +536,7 @@ def hb_add_provider(
         if endpoint:
             integration["endpoint"] = endpoint
         return _ok(client.add_provider(name, integration, is_default=is_default))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -573,7 +572,7 @@ def hb_update_provider(
         if is_default is not None:
             data["is_default"] = is_default
         return _ok(client.update_provider(provider_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -588,7 +587,7 @@ def hb_remove_provider(provider_id: str) -> str:
         client = _get_client()
         client.remove_provider(provider_id)
         return _ok({"message": f"Provider {provider_id} removed."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -622,7 +621,7 @@ def hb_list_findings(
         return _ok(
             client.list_findings(pid, status=status, severity=severity, page=page, size=size)
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -656,7 +655,7 @@ def hb_update_finding(
         if notes is not None:
             data["notes"] = notes
         return _ok(client.update_finding(pid, finding_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -682,7 +681,7 @@ def hb_retest_finding(finding_id: str, testing_level: str = "unit") -> str:
     try:
         client = _get_client()
         return _ok(client.retest_finding(finding_id, testing_level=testing_level))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -699,7 +698,7 @@ def hb_list_finding_regressions(finding_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.list_finding_regressions(finding_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -726,7 +725,7 @@ def hb_get_coverage(project_id: str | None = None, include_gaps: bool = False) -
         if not pid:
             return _err(ValueError("No project selected. Use hb_set_project first."))
         return _ok(client.get_coverage(pid, include_gaps=include_gaps))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -754,7 +753,7 @@ def hb_get_posture(project_id: str | None = None) -> str:
         if not pid:
             return _err(ValueError("No project selected. Use hb_set_project first."))
         return _ok(client.get(f"projects/{pid}/posture", include_project=True))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -771,7 +770,7 @@ def hb_get_posture_trends(project_id: str | None = None) -> str:
         if not pid:
             return _err(ValueError("No project selected. Use hb_set_project first."))
         return _ok(client.get_posture_trends(pid))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -789,7 +788,7 @@ def hb_get_shadow_posture() -> str:
     try:
         client = _get_client()
         return _ok(client.get_shadow_posture())
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -830,7 +829,7 @@ def hb_export_guardrails(
             include_project=True,
         )
         return _ok(result)
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -875,7 +874,7 @@ def hb_create_connector(
                 display_name=display_name,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -885,7 +884,7 @@ def hb_list_connectors() -> str:
     try:
         client = _get_client()
         return _ok(client.list_connectors())
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -899,7 +898,7 @@ def hb_get_connector(connector_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get_connector(connector_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -928,7 +927,7 @@ def hb_update_connector(
         if client_secret is not None:
             data["credentials"] = {"client_secret": client_secret}
         return _ok(client.update_connector(connector_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -943,7 +942,7 @@ def hb_delete_connector(connector_id: str) -> str:
         client = _get_client()
         client.delete_connector(connector_id)
         return _ok({"message": f"Connector {connector_id} deleted."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -957,7 +956,7 @@ def hb_test_connector(connector_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.test_connector(connector_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -978,7 +977,7 @@ def hb_trigger_discovery(connector_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.trigger_discovery(connector_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1022,7 +1021,7 @@ def hb_list_inventory(
                 size=size,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1036,7 +1035,7 @@ def hb_get_inventory_asset(asset_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get_inventory_asset(asset_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1077,7 +1076,7 @@ def hb_update_inventory_asset(
         if has_risk_assessment is not None:
             data["has_risk_assessment"] = has_risk_assessment
         return _ok(client.update_inventory_asset(asset_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1091,7 +1090,7 @@ def hb_archive_inventory_asset(asset_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.archive_inventory_asset(asset_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1111,7 +1110,7 @@ def hb_onboard_inventory_asset(asset_id: str, project_name: str | None = None) -
     try:
         client = _get_client()
         return _ok(client.onboard_inventory_asset(asset_id, project_name=project_name))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1131,7 +1130,7 @@ def hb_list_api_keys(page: int = 1, limit: int = 50) -> str:
     try:
         client = _get_client()
         return _ok(client.list_api_keys(page=page, limit=limit))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1146,7 +1145,7 @@ def hb_create_api_key(name: str, scope: str = "read") -> str:
     try:
         client = _get_client()
         return _ok(client.create_api_key(name, scope=scope))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1167,7 +1166,7 @@ def hb_update_api_key(key_id: str, name: str | None = None, scope: str | None = 
         if scope is not None:
             data["scope"] = scope
         return _ok(client.update_api_key(key_id, data))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1182,7 +1181,7 @@ def hb_delete_api_key(key_id: str) -> str:
         client = _get_client()
         client.delete_api_key(key_id)
         return _ok({"message": f"API key {key_id} deleted."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1197,7 +1196,7 @@ def hb_list_members() -> str:
     try:
         client = _get_client()
         return _ok(client.list_members())
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1212,7 +1211,7 @@ def hb_invite_member(email: str, access_level: str = "member") -> str:
     try:
         client = _get_client()
         return _ok(client.invite_member(email, access_level))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1227,7 +1226,7 @@ def hb_remove_member(member_id: str) -> str:
         client = _get_client()
         client.remove_member(member_id)
         return _ok({"message": f"Member {member_id} removed."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1255,7 +1254,7 @@ def hb_create_webhook(
         client = _get_client()
         types_list = [t.strip() for t in event_types.split(",")] if event_types else []
         return _ok(client.create_webhook(url=url, secret=secret, name=name, event_types=types_list))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1270,7 +1269,7 @@ def hb_delete_webhook(webhook_id: str) -> str:
         client = _get_client()
         client.delete_webhook(webhook_id)
         return _ok({"message": f"Webhook {webhook_id} deleted."})
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1284,7 +1283,7 @@ def hb_get_webhook(webhook_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.get_webhook(webhook_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1300,7 +1299,7 @@ def hb_list_webhook_deliveries(webhook_id: str, page: int = 1, size: int = 25) -
     try:
         client = _get_client()
         return _ok(client.list_webhook_deliveries(webhook_id, page=page, size=size))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1314,7 +1313,7 @@ def hb_test_webhook(webhook_id: str) -> str:
     try:
         client = _get_client()
         return _ok(client.test_webhook(webhook_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1346,7 +1345,7 @@ def hb_replay_webhook(
                 event_type=event_type,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1373,7 +1372,7 @@ def hb_get_campaign(project_id: str | None = None) -> str:
         if not pid:
             return _err(ValueError("No project selected. Use hb_set_project first."))
         return _ok(client.get_campaign(pid))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1393,7 +1392,7 @@ def hb_terminate_campaign(campaign_id: str, project_id: str | None = None) -> st
         if not pid:
             return _err(ValueError("No project selected. Use hb_set_project first."))
         return _ok(client.terminate_campaign(pid, campaign_id))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1561,7 +1560,7 @@ def hb_connect(
 
         return _ok(result)
 
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1599,7 +1598,7 @@ def hb_upload_conversations(
         return _ok(client.upload_conversations(pid, parsed, tag=tag, lang=lang))
     except json.JSONDecodeError as e:
         return _err(ValueError(f"Invalid JSON in conversations: {e}"))
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1742,7 +1741,7 @@ def hb_redteam_analyze(experiment_id: str) -> str:
                 timeout=120,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1777,7 +1776,7 @@ def hb_redteam_start(
                 include_project=True,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1804,7 +1803,7 @@ def hb_redteam_execute(experiment_id: str, session_id: str, burst_turns: int = 5
                 timeout=120,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1830,7 +1829,7 @@ def hb_redteam_direct(experiment_id: str, session_id: str, input: str) -> str:
                 include_project=True,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1856,7 +1855,7 @@ def hb_redteam_judge(experiment_id: str, session_id: str) -> str:
                 timeout=60,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 
@@ -1879,7 +1878,7 @@ def hb_redteam_complete(experiment_id: str) -> str:
                 include_project=True,
             )
         )
-    except HumanboundError as e:
+    except Exception as e:
         return _err(e)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ firewall = [
     "torch>=2.0.0",
 ]
 mcp = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
 ]
 pytest = [
     "pytest>=7.0.0",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -317,6 +317,39 @@ class TestHTTPMethods:
         assert headers["X-Custom"] == "val"
         assert headers["Authorization"] == "Bearer test-token"
 
+    @patch("humanbound_cli.client.requests.get")
+    def test_connection_error_becomes_api_error(self, mock_get, client):
+        """Transport failures surface as APIError so CLI commands and MCP
+        tools handle them through the HumanboundError hierarchy (#68)."""
+        mock_get.side_effect = requests.ConnectionError("Max retries exceeded")
+        with pytest.raises(APIError, match="Could not connect"):
+            client.get("projects")
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_timeout_becomes_api_error(self, mock_get, client):
+        mock_get.side_effect = requests.Timeout()
+        with pytest.raises(APIError, match="timed out"):
+            client.get("projects")
+
+    @patch("humanbound_cli.client.requests.post")
+    def test_post_connection_error_becomes_api_error(self, mock_post, client):
+        mock_post.side_effect = requests.ConnectionError()
+        with pytest.raises(APIError, match="Could not connect"):
+            client.post("projects", data={})
+
+    @patch("humanbound_cli.client.requests.get")
+    def test_network_api_error_message_omits_exception_detail(self, mock_get, client):
+        """The APIError message names the exception class, not its body —
+        urllib3's error text (pool internals, retry state) stays out of what
+        MCP clients and CLI users see."""
+        mock_get.side_effect = requests.ConnectionError(
+            "HTTPSConnectionPool(host='x', port=443): Max retries exceeded"
+        )
+        with pytest.raises(APIError) as exc_info:
+            client.get("projects")
+        assert "Max retries" not in str(exc_info.value)
+        assert "ConnectionError" in str(exc_info.value)
+
 
 # ---------------------------------------------------------------------------
 # Credential Persistence

--- a/tests/unit/test_mcp_error_handling.py
+++ b/tests/unit/test_mcp_error_handling.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""Source-level guard for MCP tool error handling (#68).
+
+Deliberately not gated on the [mcp] extra: this reads mcp_server.py as text,
+so it protects the invariant even in environments where mcp isn't installed."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MCP_SERVER_SRC = Path(__file__).parents[2] / "humanbound_cli" / "mcp_server.py"
+
+
+def test_every_tool_has_a_broad_exception_fallback():
+    """A tool without the `except Exception` fallback leaks FastMCP's raw
+    "Error executing tool <name>: <exception>" text to the MCP client."""
+    blocks = re.split(r"(?=@mcp\.tool\(\))", MCP_SERVER_SRC.read_text())
+    tools = {
+        re.search(r"def (\w+)\(", b).group(1): b for b in blocks if b.startswith("@mcp.tool()")
+    }
+    assert len(tools) >= 65
+    missing = [name for name, block in tools.items() if "except Exception as e:" not in block]
+    assert missing == []

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -35,3 +35,34 @@ class TestApiKeyTools:
         client.update_api_key.return_value = {"id": "k1"}
         mcp_server.hb_update_api_key("key-1", scope="admin")
         client.update_api_key.assert_called_once_with("key-1", {"scope": "admin"})
+
+
+class TestStructuredErrors:
+    """Any exception returns the {"error": ...} envelope, never a raw traceback (#68)."""
+
+    def test_non_humanbound_error_returns_envelope(self, client):
+        """Unexpected-shape bugs (KeyError/TypeError on backend responses) are
+        the class the per-tool fallback still guards — network errors already
+        become APIError inside the client."""
+        import json
+
+        client.project_id = "proj-1"
+        client.get.side_effect = TypeError("'NoneType' object is not subscriptable")
+
+        payload = json.loads(mcp_server.hb_get_posture())
+
+        assert payload["error"] is True
+        assert "NoneType" in payload["message"]
+
+    def test_humanbound_error_still_returns_envelope(self, client):
+        import json
+
+        from humanbound_cli.exceptions import APIError
+
+        client.project_id = "proj-1"
+        client.get.side_effect = APIError("backend said no")
+
+        payload = json.loads(mcp_server.hb_get_posture())
+
+        assert payload["error"] is True
+        assert "backend said no" in payload["message"]


### PR DESCRIPTION
## Summary

Supersedes #68 (thanks @JChario — the report and the per-tool fix are yours),
implementing the direction from the review discussion there: the root cause is
fixed in the client, and the per-tool handlers are broadened.

- **`client.py`**: transport failures (connection refused, DNS, timeout) become
  `APIError` at the source, so CLI commands and all 65 MCP tools handle them
  through the `HumanboundError` hierarchy. Previously they escaped as raw
  requests exceptions — CLI commands crashed with a traceback, MCP clients got
  FastMCP's raw "Error executing tool …" text. The message names the exception
  class only, keeping urllib3 internals out of user-visible output.
- **`mcp_server.py`**: every tool (65 — the 63 from #68 plus the two 2.7.0
  finding-regression tools) now catches broad `Exception` into the structured
  `{"error": …}` envelope, which also covers response-shape bugs
  (`KeyError`/`TypeError` on unexpected backend payloads) that no client-layer
  fix can reach. A source-level test enforces the invariant for future tools
  without needing the `[mcp]` extra installed.
- **`pyproject.toml`**: pin `mcp>=1.2.0,<2` — mcp 2.0.0 (2026-07-28) removed
  `mcp.server.fastmcp`, breaking `hb mcp` at import on fresh installs.

## Test plan

- New tests: 4 client network-wrap tests (including one pinning the clean
  message), 2 MCP envelope tests, and the source-scan guard.
- Verified end-to-end: `hb projects list` against a dead backend (raw traceback
  on main → one clean error line here), and a real `hb mcp` subprocess over
  stdio — 65 tools registered, dead backend returns the structured envelope as
  a normal tool result.
- Full suite: 1050 passed (+1 skip) without the mcp extra, 1055 with it.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` — not needed: error-message text and
      dependency pin, no documented behavior changes
- [x] All commits are signed off (`git commit -s`)

## Linked issue(s)

Supersedes #68.