### PR TITLE
chore(engine): drop redundant comment on secure result writes

### DIFF
--- a/humanbound_cli/engine/local_runner.py
+++ b/humanbound_cli/engine/local_runner.py
@@ -237,8 +237,6 @@ class _LocalRun:
             completed_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
         )
 
-        # meta.json / logs.jsonl hold attack prompts and agent replies —
-        # write atomically at 0600 like credentials.json.
         write_secure_file(
             results_dir / "meta.json",
             json.dumps(meta.model_dump(), indent=2, default=str),


### PR DESCRIPTION
## Summary

Removes a two-line inline comment above the `write_secure_file` calls in
`_LocalRun._save_results`. The helper name says what happens; the why (result
artifacts hold attack prompts and agent replies, written `0600` like
`credentials.json`) is already recorded in #103's changelog entry.

Comment-only change — no behavior difference.

## Type of change

- [x] Documentation only

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix — N/A, no behavior change
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally (1079 passed)
- [x] `CHANGELOG.md` updated under `[Unreleased]` — N/A, comment-only, not user-visible
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — N/A, not user-visible
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

None — follow-up cleanup after #103.
