### PR TITLE
fix: replace bare except clauses with specific exception handling

### DIFF
--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -402,7 +402,8 @@ class Bot(ResponseExtractor):
         try:
             # by default assume json response
             return resp.json(), time.time() - t_start, endpoint
-        except:
+        except (json.JSONDecodeError, ValueError):
+            # Only catch JSON parsing errors, not SystemExit/KeyboardInterrupt
             return resp.text, time.time() - t_start, endpoint
 
     # resolve the chat_completion request config - single source of truth for all
@@ -779,7 +780,8 @@ class Telemetry:
 
         try:
             return resp.json()
-        except:
+        except (json.JSONDecodeError, ValueError):
+            # Only catch JSON parsing errors, not SystemExit/KeyboardInterrupt
             return resp.text
 
     #


### PR DESCRIPTION
## Summary

Bare `except:` in `humanbound_cli/engine/bot.py` response parsing also caught `KeyboardInterrupt` / `SystemExit`, so Ctrl+C could leave long runs unresponsive. Catch only `json.JSONDecodeError` and `ValueError` so control-flow exceptions propagate.

## Changes

- `humanbound_cli/engine/bot.py`: two bare `except:` → `except (json.JSONDecodeError, ValueError):` (bot chat response + telemetry JSON parse)

## Test plan

- [ ] `ruff check` / `ruff format --check` clean
- [ ] `pytest tests/unit/test_engine_bot.py -q`
- [ ] Confirm interrupting a long local run with Ctrl+C exits instead of hanging in these parse paths
