### PR TITLE
feat: add logging to silent engine exception handlers

### DIFF
--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -165,7 +165,8 @@ class Bot(ResponseExtractor):
 
             return current
 
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Failed to navigate nested dict path: {e}")
             return None
 
     #
@@ -482,7 +483,8 @@ class Bot(ResponseExtractor):
                 raw_data = await socket.recv()
                 try:
                     chunk = json.loads(raw_data)
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Failed to parse SSE chunk: {e}")
                     break
                 buffer, stop, _ = self.__process_chunk(chunk, buffer)
                 if stop:
@@ -491,7 +493,8 @@ class Bot(ResponseExtractor):
 
         try:
             return await asyncio.wait_for(read_complete_message(), REQUESTS_TIMEOUT)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Error reading complete message: {e}")
             await asyncio.wait_for(socket.close(), REQUESTS_TIMEOUT)
             raise
 
@@ -906,7 +909,8 @@ class Telemetry:
                         for obs in trace_detail.get("observations", []):
                             obs["_turn"] = turn_idx
                         observations.extend(trace_detail.get("observations", []))
-                    except Exception:
+                    except Exception as e:
+                        logger.debug(f"Failed to process trace detail: {e}")
                         continue
             total_tokens = 0
             total_cost = 0
@@ -1545,8 +1549,9 @@ class Telemetry:
             # All retries exhausted — return whatever we got (may be empty)
             return standardized if raw_data else None
 
-        except Exception:
+        except Exception as e:
             # Graceful degradation — continue without telemetry
+            logger.debug(f"Failed to standardize telemetry data: {e}")
             return None
 
     @staticmethod
@@ -1589,7 +1594,8 @@ class Telemetry:
 
             return current
 
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Failed to navigate nested dict path: {e}")
             return None
 
     @staticmethod
@@ -1695,8 +1701,9 @@ class Telemetry:
 
             return standardized
 
-        except Exception:
+        except Exception as e:
             # Return empty standardized structure on error
+            logger.debug(f"Failed to standardize bot response: {e}")
             return {
                 "tool_executions": [],
                 "memory_operations": [],

--- a/humanbound_cli/engine/platform_runner.py
+++ b/humanbound_cli/engine/platform_runner.py
@@ -6,7 +6,11 @@ This is a thin adapter. No new logic — just translates between the TestRunner
 canonical shapes and the existing API responses. The platform backend is unchanged.
 """
 
+import logging
+
 from .runner import PaginatedLogs, Posture, TestConfig, TestResult, TestRunner, TestStatus
+
+logger = logging.getLogger("humanbound.engine.platform_runner")
 
 
 class PlatformTestRunner(TestRunner):
@@ -56,7 +60,8 @@ class PlatformTestRunner(TestRunner):
             exp = self.client.get_experiment(experiment_id)
             stats = exp.get("results", {}).get("stats", {})
             log_count = stats.get("total", 0)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Failed to fetch experiment stats for {experiment_id}: {e}")
             log_count = 0
 
         return TestStatus(
@@ -140,8 +145,8 @@ class PlatformTestRunner(TestRunner):
                 prev = data_points[-2]
                 posture.previous_grade = prev.get("grade")
                 posture.previous_score = prev.get("score")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to fetch posture trends for project {project_id}: {e}")
 
         return posture
 

--- a/humanbound_cli/engine/scope.py
+++ b/humanbound_cli/engine/scope.py
@@ -208,7 +208,8 @@ def from_probe(integration, llm_pinger):
 
                 response, _, _ = asyncio.run(bot.ping(payload, probe))
                 responses.append(f"Q: {probe}\nA: {response}")
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Failed to probe bot with '{probe}': {e}")
                 continue
 
         if not responses:


### PR DESCRIPTION
## Summary

Several engine exception handlers swallowed failures with no log output. Add `logger.debug(...)` on those paths (and a logger for `platform_runner`) so probe/telemetry/stats failures are diagnosable without changing control flow.

## Changes

- `humanbound_cli/engine/bot.py`: debug logs on nested-path nav, SSE chunk parse, socket read, trace-detail processing, telemetry/bot standardization failures
- `humanbound_cli/engine/platform_runner.py`: add logger; debug logs on experiment stats and posture-trend fetch failures
- `humanbound_cli/engine/scope.py`: debug log when a probe call fails

## Test plan

- [ ] `ruff check` / `ruff format --check` clean
- [ ] `pytest tests/unit/ -q` (engine-related)
- [ ] With debug logging enabled, a failed probe/stats path emits a debug line and still degrades gracefully
