### PR TITLE
feat: add defensive checks for nested API response parsing

### DIFF
--- a/humanbound_cli/commands/connect.py
+++ b/humanbound_cli/commands/connect.py
@@ -330,8 +330,9 @@ def _derive_agent_name(endpoint: str) -> str:
         path = Path(endpoint)
         raw = path.read_text() if path.is_file() else endpoint
         config = json.loads(raw)
-        ep_url = config.get("chat_completion", {}).get("endpoint", "")
-        if ep_url:
+        chat_completion = config.get("chat_completion") if isinstance(config, dict) else {}
+        ep_url = chat_completion.get("endpoint", "") if isinstance(chat_completion, dict) else ""
+        if ep_url and isinstance(ep_url, str):
             hostname = urlparse(ep_url).hostname
             if hostname:
                 # Extract first subdomain segment as agent name
@@ -597,7 +598,12 @@ def _connect_agent_platform(
             integration = vendor_integration or (_load_integration(endpoint) if endpoint else None)
             if integration:
                 local_integration = integration
-                chat_ep = integration.get("chat_completion", {}).get("endpoint", "")
+                chat_completion = (
+                    integration.get("chat_completion") if isinstance(integration, dict) else {}
+                )
+                chat_ep = (
+                    chat_completion.get("endpoint", "") if isinstance(chat_completion, dict) else ""
+                )
                 console.print(
                     f"  [green]\u2713[/green] Endpoint integration: [dim]{chat_ep or '(from config)'}[/dim]"
                 )
@@ -669,7 +675,12 @@ def _connect_agent_platform(
             # --endpoint / --vendor -> endpoint source (API probing)
             integration = vendor_integration or (_load_integration(endpoint) if endpoint else None)
             if integration:
-                chat_ep = integration.get("chat_completion", {}).get("endpoint", "")
+                chat_completion = (
+                    integration.get("chat_completion") if isinstance(integration, dict) else {}
+                )
+                chat_ep = (
+                    chat_completion.get("endpoint", "") if isinstance(chat_completion, dict) else ""
+                )
                 console.print(
                     f"  [green]\u2713[/green] Endpoint source: [dim]{chat_ep or '(from config)'}[/dim]"
                 )
@@ -838,7 +849,12 @@ def _connect_agent_local(endpoint, name, prompt, repo, openapi, context, level, 
     if endpoint:
         try:
             integration = _load_integration(endpoint)
-            chat_ep = integration.get("chat_completion", {}).get("endpoint", "")
+            chat_completion = (
+                integration.get("chat_completion") if isinstance(integration, dict) else {}
+            )
+            chat_ep = (
+                chat_completion.get("endpoint", "") if isinstance(chat_completion, dict) else ""
+            )
             console.print(
                 f"  [green]✓[/green] Endpoint source: [dim]{chat_ep or '(from config)'}[/dim]"
             )

--- a/humanbound_cli/commands/firewall.py
+++ b/humanbound_cli/commands/firewall.py
@@ -356,7 +356,8 @@ def _fetch_logs(client, experiments):
 def _fetch_intents(client, project_id):
     try:
         data = client.get(f"projects/{project_id}")
-        intents = data.get("scope", {}).get("intents", {})
+        scope = data.get("scope") if isinstance(data, dict) else {}
+        intents = scope.get("intents", {}) if isinstance(scope, dict) else {}
         return intents.get("permitted", []), intents.get("restricted", [])
     except Exception:
         return None, None

--- a/humanbound_cli/commands/redteam.py
+++ b/humanbound_cli/commands/redteam.py
@@ -188,7 +188,7 @@ def sessions_command(experiment_id):
             s.get("user_id", ""),
             s.get("status", ""),
             str(s.get("turn_count", 0)),
-            s.get("strategy", {}).get("goal", "")[:40],
+            (s.get("strategy") if isinstance(s.get("strategy"), dict) else {}).get("goal", "")[:40],
         )
 
     console.print(table)
@@ -315,7 +315,8 @@ def _interactive_loop(client, experiment_id):
                     )
 
                 active_session = result.get("session_id")
-                strategy_goal = result.get("strategy", {}).get("goal", "")
+                strategy = result.get("strategy") if isinstance(result, dict) else {}
+                strategy_goal = strategy.get("goal", "") if isinstance(strategy, dict) else ""
                 console.print("\n[green]Session started[/green]")
                 console.print(f"  Strategy: [bold]{strategy_goal}[/bold]")
 
@@ -547,6 +548,6 @@ def _get_project_scope(client):
     """Get the project scope for experiment configuration."""
     try:
         project = client.get(f"projects/{client.project_id}", include_project=True)
-        return project.get("scope", {})
+        return project.get("scope", {}) if isinstance(project, dict) else {}
     except Exception:
         return {}

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -482,8 +482,14 @@ def test_command(
             try:
                 client = runner.client
                 project = client.get(f"projects/{client.project_id}", include_project=True)
-                default_integ = project.get("default_integration") or {}
-                has_telemetry = bool(default_integ.get("telemetry"))
+                default_integ = (
+                    project.get("default_integration") if isinstance(project, dict) else {}
+                )
+                has_telemetry = (
+                    bool(default_integ.get("telemetry"))
+                    if isinstance(default_integ, dict)
+                    else False
+                )
             except Exception:
                 has_telemetry = False
         else:

--- a/humanbound_cli/engine/bot.py
+++ b/humanbound_cli/engine/bot.py
@@ -847,12 +847,18 @@ class Telemetry:
                 total_tokens = 0
                 for run in raw_data["runs"]:
                     if run.get("run_type") == "tool":
+                        inputs = run.get("inputs") if isinstance(run, dict) else {}
+                        outputs = run.get("outputs") if isinstance(run, dict) else {}
                         standardized["tool_executions"].append(
                             {
                                 "turn": run.get("turn", 0),
                                 "tool_name": run.get("name", ""),
-                                "parameters": run.get("inputs", {}).get("tool_input", {}),
-                                "result": run.get("outputs", {}).get("result", ""),
+                                "parameters": inputs.get("tool_input", {})
+                                if isinstance(inputs, dict)
+                                else {},
+                                "result": outputs.get("result", "")
+                                if isinstance(outputs, dict)
+                                else "",
                                 "execution_time_ms": run.get("execution_time", 0),
                             }
                         )
@@ -1457,7 +1463,12 @@ class Telemetry:
     def auth(self):
         """Optional: Get telemetry-specific access token"""
         try:
-            endpoint = self.config.get("telemetry_auth", {}).get("endpoint", "")
+            telemetry_auth = (
+                self.config.get("telemetry_auth") if isinstance(self.config, dict) else {}
+            )
+            endpoint = (
+                telemetry_auth.get("endpoint", "") if isinstance(telemetry_auth, dict) else ""
+            )
             if endpoint == "":
                 return {}
 

--- a/humanbound_cli/engine/scope.py
+++ b/humanbound_cli/engine/scope.py
@@ -110,13 +110,22 @@ def from_scope_file(path):
         data = json.loads(content)
 
     # Normalize to expected shape
+    if not isinstance(data, dict):
+        return {
+            "overall_business_scope": "",
+            "intents": {"permitted": [], "restricted": []},
+            "more_info": "",
+        }
+    intents_data = data.get("intents")
+    if not isinstance(intents_data, dict):
+        intents_data = {}
     return {
         "overall_business_scope": data.get(
             "business_scope", data.get("overall_business_scope", "")
         ),
         "intents": {
-            "permitted": data.get("permitted", data.get("intents", {}).get("permitted", [])),
-            "restricted": data.get("restricted", data.get("intents", {}).get("restricted", [])),
+            "permitted": data.get("permitted", intents_data.get("permitted", [])),
+            "restricted": data.get("restricted", intents_data.get("restricted", [])),
         },
         "more_info": data.get("more_info", data.get("risk_context", "")),
     }

--- a/humanbound_cli/mcp_server.py
+++ b/humanbound_cli/mcp_server.py
@@ -1461,7 +1461,12 @@ def hb_connect(
         # -- Derive project name ------------------------------------------
         if not name:
             try:
-                ep_url = bot_config.get("chat_completion", {}).get("endpoint", "")
+                chat_completion = (
+                    bot_config.get("chat_completion") if isinstance(bot_config, dict) else {}
+                )
+                ep_url = (
+                    chat_completion.get("endpoint", "") if isinstance(chat_completion, dict) else ""
+                )
                 if ep_url:
                     from urllib.parse import urlparse
 


### PR DESCRIPTION
## Summary

Chained `.get(...).get(...)` assumes intermediate values are dicts. When the API returns `None` or another type, that raises `AttributeError`. Guard nested access with `isinstance(..., dict)` checks.

## Changes

- `humanbound_cli/commands/connect.py`: safe `chat_completion.endpoint` extraction
- `humanbound_cli/commands/firewall.py`, `redteam.py`, `test.py`: safe scope/strategy/integration reads
- `humanbound_cli/engine/bot.py`: safe tool input/output and `telemetry_auth` reads
- `humanbound_cli/engine/scope.py`: safe scope-file normalization (keeps top-level `permitted`/`restricted` fallback)
- `humanbound_cli/mcp_server.py`: safe endpoint URL extraction

## Test plan

- [ ] `ruff check` / `ruff format --check` clean
- [ ] `pytest tests/unit/ -q`
- [ ] Spot-check connect/redteam paths with a malformed nested field (`null` where a dict is expected) — no AttributeError
