### PR TITLE
feat: add debug context to command exception handlers

### DIFF
--- a/humanbound_cli/commands/connect.py
+++ b/humanbound_cli/commands/connect.py
@@ -3,6 +3,7 @@
 """Connect command — unified entry point for agent and platform onboarding."""
 
 import json
+import logging
 import random
 import threading
 import time
@@ -19,6 +20,7 @@ from ..exceptions import APIError, NotAuthenticatedError
 from .test import _load_integration, _resolve_context
 
 console = Console()
+logger = logging.getLogger("humanbound.commands.connect")
 
 SCAN_TIMEOUT = 180
 DEFAULT_TEST_CATEGORY = "humanbound/adversarial/owasp_agentic"
@@ -337,8 +339,8 @@ def _derive_agent_name(endpoint: str) -> str:
                 # Extract first subdomain segment as agent name
                 agent = hostname.split(".")[0]
                 return f"{agent}.{suffix}"
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Failed to extract agent name from endpoint: {e}")
     return f"agent.{suffix}"
 
 

--- a/humanbound_cli/commands/experiments.py
+++ b/humanbound_cli/commands/experiments.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024-2026 Humanbound
 """Experiment commands."""
 
+import logging
 import time
 
 import click
@@ -16,6 +17,7 @@ from ..client import HumanboundClient
 from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
+logger = logging.getLogger("humanbound.commands.experiments")
 
 
 @click.group("experiments", invoke_without_command=True)
@@ -387,8 +389,9 @@ def _show_failure_details(client: HumanboundClient, experiment_id: str):
                 explanation = insight.get("explanation", "")
                 if explanation:
                     console.print(f"  {explanation}")
-    except Exception:
-        pass  # Don't fail the status display if we can't fetch details
+    except Exception as e:
+        logger.debug(f"Failed to fetch experiment details: {e}")
+        # Don't fail the status display if we can't fetch details
 
 
 @experiments_group.command("wait")

--- a/humanbound_cli/commands/firewall.py
+++ b/humanbound_cli/commands/firewall.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024-2026 Humanbound
 """Firewall commands — train and manage Tier 2 classifiers for humanbound-firewall."""
 
+import logging
 import os
 import sys
 import time
@@ -17,6 +18,7 @@ from ..engine.platform_runner import PlatformTestRunner
 from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
+logger = logging.getLogger("humanbound.commands.firewall")
 
 
 @click.group("firewall")
@@ -358,5 +360,6 @@ def _fetch_intents(client, project_id):
         data = client.get(f"projects/{project_id}")
         intents = data.get("scope", {}).get("intents", {})
         return intents.get("permitted", []), intents.get("restricted", [])
-    except Exception:
+    except Exception as e:
+        logger.debug(f"Failed to fetch project scope for {project_id}: {e}")
         return None, None

--- a/humanbound_cli/commands/redteam.py
+++ b/humanbound_cli/commands/redteam.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024-2026 Humanbound
 """Collaborative red team command — interactive human-AI adversarial testing."""
 
+import logging
+
 import click
 import requests as requests_lib
 from rich.console import Console
@@ -14,6 +16,7 @@ from ..client import HumanboundClient
 from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
+logger = logging.getLogger("humanbound.commands.redteam")
 console_err = Console(stderr=True)
 
 COLLABORATIVE_TEST_CATEGORY = "humanbound/adversarial/collaborative_red_team"
@@ -548,5 +551,6 @@ def _get_project_scope(client):
     try:
         project = client.get(f"projects/{client.project_id}", include_project=True)
         return project.get("scope", {})
-    except Exception:
+    except Exception as e:
+        logger.debug(f"Failed to fetch project scope: {e}")
         return {}

--- a/humanbound_cli/commands/test.py
+++ b/humanbound_cli/commands/test.py
@@ -3,6 +3,7 @@
 """Test command for running security experiments."""
 
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from ..engine.schemas import severity_to_label
 from ..exceptions import APIError, NotAuthenticatedError
 
 console = Console()
+logger = logging.getLogger("humanbound.commands.test")
 
 # Process exit codes — part of the CI contract, documented in `hb test --help`.
 # The 1 vs 2 split follows the grep/pytest convention: "the scan ran and found
@@ -389,8 +391,9 @@ def test_command(
     # --- Runner selection (login + project is the switch) ---
     try:
         runner = get_runner(force_local=local)
-    except Exception:
+    except Exception as e:
         # Fallback: try platform if get_runner fails
+        logger.debug(f"Failed to get local runner, trying platform: {e}")
         runner = None
 
     is_platform = isinstance(runner, PlatformTestRunner)
@@ -484,7 +487,8 @@ def test_command(
                 project = client.get(f"projects/{client.project_id}", include_project=True)
                 default_integ = project.get("default_integration") or {}
                 has_telemetry = bool(default_integ.get("telemetry"))
-            except Exception:
+            except Exception as e:
+                logger.debug(f"Failed to check telemetry status: {e}")
                 has_telemetry = False
         else:
             has_telemetry = False
@@ -597,7 +601,8 @@ def test_command(
                 _findings_seen = int(posture.finding_count)
             else:
                 _findings_seen = len(result.insights or [])
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Failed to count findings: {e}")
             _findings_seen = 0
 
         # Display results (same rendering, canonical shapes)


### PR DESCRIPTION
## Summary

CLI command paths often swallowed exceptions with `pass` / silent fallbacks. Add module loggers and `logger.debug(...)` so connect/test/experiments/firewall/redteam failures leave a trace without changing graceful degradation.

This does **not** change user-facing error strings; it adds debug context for operators.

## Changes

- `humanbound_cli/commands/connect.py`: logger + debug on agent-name derivation failure
- `humanbound_cli/commands/test.py`: logger + debug on runner init, telemetry check, findings count failures
- `humanbound_cli/commands/experiments.py`: logger + debug when experiment details fetch fails
- `humanbound_cli/commands/firewall.py`: logger + debug when project scope fetch fails
- `humanbound_cli/commands/redteam.py`: logger + debug when project scope fetch fails

## Test plan

- [ ] `ruff check` / `ruff format --check` clean
- [ ] `pytest tests/unit/ -q`
- [ ] With debug logging enabled, a failed scope/details fetch logs and the command still continues
