### PR TITLE
chore(release): prepare v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] — 2026-08-14
+
 ### Added
 - **`hb assessments create -t <category>`** — create and run a custom
   assessment from your own test categories, e.g.
@@ -82,6 +84,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   slow-but-successful category as failed — never actually bound the run. A
   worker crash also no longer prints its traceback twice on stderr; the full
   trace still reaches the error callback and DEBUG logging.
+- **Local experiment starts no longer collide within the same second.** Each
+  local run ID now includes a short UUID suffix (`exp-{timestamp}-{uuid8}`), so
+  concurrent `hb test` processes no longer overwrite each other's `_runs` slot
+  or result directory.
+- **OpenAPI extraction now resolves `$ref` parameters and request body
+  schemas.** The parser previously skipped every `$ref` parameter and only read
+  inline `properties`, so component-based specs produced incomplete parameter
+  lists on the extractor. Local JSON Pointer resolution (with cycle-safe
+  `allOf` walking and depth guards) now follows `#/components/...` and Swagger 2
+  `#/parameters/...` refs. This is groundwork for consumers of `parameters` /
+  `responses`; `hb connect` today still reads only description/method/path/
+  summary from the parse result.
 
 ### Security
 - **OAuth callback listeners are loopback-only and path-validated.** Login and
@@ -104,20 +118,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `os.replace` helper and are never world-readable. The OAuth login callback
   error page also escapes the reflected `error_description` to prevent a
   reflected-XSS in that page.
-
-### Fixed
-- **Local experiment starts no longer collide within the same second.** Each
-  local run ID now includes a short UUID suffix (`exp-{timestamp}-{uuid8}`), so
-  concurrent `hb test` processes no longer overwrite each other's `_runs` slot
-  or result directory.
-- **OpenAPI extraction now resolves `$ref` parameters and request body
-  schemas.** The parser previously skipped every `$ref` parameter and only read
-  inline `properties`, so component-based specs produced incomplete parameter
-  lists on the extractor. Local JSON Pointer resolution (with cycle-safe
-  `allOf` walking and depth guards) now follows `#/components/...` and Swagger 2
-  `#/parameters/...` refs. This is groundwork for consumers of `parameters` /
-  `responses`; `hb connect` today still reads only description/method/path/
-  summary from the parse result.
 
 ## [2.8.0] — 2026-07-30
 
@@ -684,7 +684,8 @@ Last release as `humanbound-cli`. See the
 [old release](https://pypi.org/project/humanbound-cli/1.1.0/) on PyPI for
 notes — that history is preserved there and is not re-documented here.
 
-[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.8.0...HEAD
+[Unreleased]: https://github.com/humanbound/humanbound/compare/v2.9.0...HEAD
+[2.9.0]: https://github.com/humanbound/humanbound/releases/tag/v2.9.0
 [2.8.0]: https://github.com/humanbound/humanbound/releases/tag/v2.8.0
 [2.7.0]: https://github.com/humanbound/humanbound/releases/tag/v2.7.0
 [2.6.0]: https://github.com/humanbound/humanbound/releases/tag/v2.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "humanbound"
-version = "2.8.0"
+version = "2.9.0"
 description = "Open-source adversarial testing engine, SDK, and CLI for AI agents."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Bump the package version to 2.9.0 and cut the Unreleased section into a
dated 2.9.0 entry, with the compare/tag links updated to match.

The Unreleased block had accumulated two separate "Fixed" sections; they
are merged into one so the extracted release notes carry a single Fixed
heading. Bullet text is unchanged.

## Summary

Release preparation for v2.9.0. Two files change:

- **`pyproject.toml`** — version `2.8.0` → `2.9.0`. This is the single version
  source; `__version__` resolves from installed package metadata, so nothing
  else needs touching.
- **`CHANGELOG.md`** — `## [2.9.0] — 2026-08-14` is inserted between
  `## [Unreleased]` and the accumulated sections, claiming them for this
  release. The `[Unreleased]` link now compares from `v2.9.0`, and a `[2.9.0]`
  tag link is added.

The `Unreleased` block had two separate `### Fixed` headings — the
collision-safe experiment ID and OpenAPI `$ref` entries had landed in a second
one below `### Security`. They are merged into the first `Fixed` section so the
GitHub Release body carries one heading per section, matching 2.8.0's
`Added / Changed / Fixed / Security` order. The move is text-identical; no
bullet was reworded.

Release notes are extracted by `awk` in `.github/workflows/release.yml`, which
reads everything between `## [2.9.0]` and the next `## [` heading — verified to
produce a non-empty 107-line body with all four sections.

Merging this and pushing the `v2.9.0` tag triggers the PyPI publish, the GitHub
Release, and the multi-arch GHCR image build.

## Type of change

- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix — n/a, no code change
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally — 1225 passed, all checks passed, 170 files already formatted
- [x] `CHANGELOG.md` updated under `[Unreleased]` — this PR converts `[Unreleased]` into the dated `[2.9.0]` entry
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — n/a, each feature shipped its own docs
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

<!-- none -->
