### PR TITLE
docs: use the #start-here Discord invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/humanbound/humanbound/discussions
     about: Use Discussions for questions, ideas, and show-and-tell.
   - name: Discord community
-    url: https://discord.gg/WgTMpmSFtN
+    url: https://discord.gg/QFTD6tr9zu
     about: Chat with the community and the maintainers.
   - name: Documentation
     url: https://docs.humanbound.ai/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Discord links now point at the `#start-here` invite** (#132).
+  `README.md`, `CONTRIBUTING.md`, `pyproject.toml`, the new-issue chooser, and
+  the community and plugins docs pages used `discord.gg/WgTMpmSFtN`, which
+  opens in `#general`. They now use `discord.gg/QFTD6tr9zu`, the invite
+  www.humanbound.ai already links to. Both codes are live and both open the
+  same server, so links already in the wild keep working.
+
 ## [2.9.0] — 2026-08-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ for the current cadence and supported-version matrix.
 
 ## Community
 
-- **Discord** — [discord.gg/WgTMpmSFtN](https://discord.gg/WgTMpmSFtN) for questions
+- **Discord** — [discord.gg/QFTD6tr9zu](https://discord.gg/QFTD6tr9zu) for questions
   and discussion
 - **Discussions** — on the GitHub repo, for longer-form topics
 - **Docs** — [docs.humanbound.ai](https://docs.humanbound.ai)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="https://pypi.org/project/humanbound/"><img src="https://img.shields.io/pypi/dm/humanbound?style=flat-square&color=FD9506" alt="Downloads"/></a>
   <a href="https://github.com/humanbound/humanbound/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/humanbound/humanbound/ci.yml?style=flat-square&color=FD9506" alt="CI"/></a>
   <a href="https://github.com/humanbound/humanbound/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-FD9506?style=flat-square" alt="License"/></a>
-  <a href="https://discord.gg/WgTMpmSFtN"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
+  <a href="https://discord.gg/QFTD6tr9zu"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
   <a href="https://docs.humanbound.ai/"><img src="https://img.shields.io/badge/docs-humanbound.ai-FD9506?style=flat-square" alt="Docs"/></a>
 </p>
 
@@ -234,7 +234,7 @@ loop, release process, and DCO sign-off requirement (see [DCO.md](https://github
 - 🐛 [Report a bug](https://github.com/humanbound/humanbound/issues/new/choose)
 - 💡 [Request a feature](https://github.com/humanbound/humanbound/issues/new/choose)
 - 🔒 [Report a security issue](https://github.com/humanbound/humanbound/blob/main/SECURITY.md) — **not via public Issues**
-- 💬 [Join Discord](https://discord.gg/WgTMpmSFtN)
+- 💬 [Join Discord](https://discord.gg/QFTD6tr9zu)
 
 ## Telemetry
 

--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -22,7 +22,7 @@ Four channels for help, feedback, and updates: the Humanbound Discord server for
 
     Join the community server for support, feature discussions, and early access announcements.
 
-    [:octicons-link-external-16: Join Discord](https://discord.gg/WgTMpmSFtN)
+    [:octicons-link-external-16: Join Discord](https://discord.gg/QFTD6tr9zu)
 
 - :computer: **GitHub**
 

--- a/docs/docs/plugins/index.md
+++ b/docs/docs/plugins/index.md
@@ -98,4 +98,4 @@ depend on a particular shape.
 
 - **Repository:** [github.com/humanbound/plugins](https://github.com/humanbound/plugins)
 - **Roadmap:** [github.com/humanbound/plugins/blob/main/ROADMAP.md](https://github.com/humanbound/plugins/blob/main/ROADMAP.md)
-- **Discord:** [discord.gg/WgTMpmSFtN](https://discord.gg/WgTMpmSFtN)
+- **Discord:** [discord.gg/QFTD6tr9zu](https://discord.gg/QFTD6tr9zu)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ Repository = "https://github.com/humanbound/humanbound"
 Issues = "https://github.com/humanbound/humanbound/issues"
 Changelog = "https://github.com/humanbound/humanbound/blob/main/CHANGELOG.md"
 Community = "https://docs.humanbound.ai/community/"
-Discord = "https://discord.gg/WgTMpmSFtN"
+Discord = "https://discord.gg/QFTD6tr9zu"
 
 [tool.setuptools.packages.find]
 include = ["humanbound*", "humanbound_cli*"]


### PR DESCRIPTION
## Summary

Points every Discord link in this repo at `https://discord.gg/QFTD6tr9zu`, the invite www.humanbound.ai already uses. It opens in `#start-here` instead of `#general`.

Seven references across `README.md`, `CONTRIBUTING.md`, `pyproject.toml`, the new-issue chooser, and the community and plugins docs pages. `CHANGELOG.md:265-267` is left as it is, since that entry records what #55 did.

Both codes are live and open the same server (guild `1050324540653322300`), so links already published keep working.

## Type of change

- [x] Documentation only

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] All commits are signed off (`git commit -s`)

Two things worth knowing at review time. The `pyproject.toml` link is what PyPI renders in the project sidebar, so it only changes there on the next release. And `docs.yml` filters on `paths: ['docs/**']`, so the two docs pages ride in this PR rather than a follow-up, otherwise docs.humanbound.ai would not rebuild.

## Linked issue(s)

Closes #132

## Companion PRs

The same change in the other four repos:

- humanbound/.github#2
- humanbound/plugins#8
- humanbound/humanbound-firewall#20
- humanbound/actions#10

Cross-repo context is in humanbound/humanbound#132.
