### PR TITLE
Restore verbatim Apache-2.0 license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,3 @@
-humanbound
-Copyright (C) 2024-2026 AI and Me Single-Member Private Company (also known as Humanbound)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-===============================================================================
 
                                  Apache License
                            Version 2.0, January 2004
@@ -154,8 +138,8 @@ limitations under the License.
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -179,15 +163,40 @@ limitations under the License.
       other commercial damages or losses), even if such Contributor
       has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Support. While redistributing the Work or
-      Derivative Works thereof, You may choose to offer, and charge a
-      fee for, acceptance of support, warranty, indemnity, or other
-      liability obligations and/or rights consistent with this License.
-      However, in accepting such obligations, You may act only on Your
-      own behalf and on Your sole responsibility, not on behalf of any
-      other Contributor, and only if You agree to indemnify, defend,
-      and hold each Contributor harmless for any liability incurred by,
-      or claims asserted against, such Contributor by reason of your
-      accepting any such warranty or support.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024-2026 AI and Me Single-Member Private Company (also known as Humanbound)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary

`LICENSE` had drifted from the canonical Apache-2.0 text. This restores it verbatim.

- **Section 6 (Trademarks)** — read "except as required for describing the origin of the Work"; canonical is "except as required for **reasonable and customary use in** describing the origin of the Work".
- **Section 9** — was titled "Accepting Warranty or **Support**"; canonical is "Accepting Warranty or **Additional Liability**" (same substitution in the closing line).
- **Appendix** — the standard "How to apply the Apache License to your work" boilerplate was missing; added.
- **Project header removed** — the copyright notice and license blurb that preceded `Apache License / Version 2.0, January 2004`. Our copyright assertion lives in `NOTICE`, which is unchanged.

This has a concrete effect: the file currently fails GitHub's license detection and the repo reports as `NOASSERTION` —

```console
$ gh api repos/humanbound/humanbound --jq '.license.spdx_id'
NOASSERTION
```

Restoring the canonical text should resolve it to `Apache-2.0`. (`.license.spdx_id` comes from license-*text* matching, so the appendix copyright line is orthogonal to this.)

`LICENSE` now differs from <https://www.apache.org/licenses/LICENSE-2.0.txt> only in the appendix copyright line, which the appendix itself instructs you to fill in:

```diff
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-2026 AI and Me Single-Member Private Company (also known as Humanbound)
```

Reviewers can confirm with:

```bash
diff <(curl -sS https://www.apache.org/licenses/LICENSE-2.0.txt) LICENSE
```

The license grant itself is unchanged — the project was and remains Apache-2.0. No code, no behavior change.

## Type of change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Documentation only
- [ ] Build / tooling / CI

## Checklist
- [ ] Tests added — n/a, no code changed
- [x] `pytest`, `ruff check`, and `ruff format --check` pass
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — n/a, not a user-visible behavior change
- [ ] Docs updated on `docs.humanbound.ai` — n/a
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)
<!-- none -->