### PR TITLE
fix(mcp): report why the MCP import failed; exercise the [mcp] extra …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -43,7 +43,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - run: python -m pip install --upgrade pip
-      - run: pip install -e '.[dev,engine]'
+      - run: pip install -e '.[dev,engine,mcp]'
+      # Not redundant with pytest: the MCP suite silently self-skips when the SDK is absent.
+      - name: Verify the [mcp] extra imports
+        run: python -c "import mcp, humanbound_cli.mcp_server"
       - run: pytest -v --timeout=60
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`hb mcp` now reports why the MCP import failed** (#135, thanks
+  @iayanpahwa). A missing SDK and an installed-but-incompatible SDK both
+  printed "MCP dependencies not installed", sending users to re-run an install
+  that had already succeeded. The error now carries the underlying import
+  failure, so an incompatible SDK names itself.
+- **CI installs and exercises the `[mcp]` extra.** The test job installed only
+  `[dev,engine]`, so `pytest.importorskip("mcp")` skipped the entire MCP suite
+  and an unusable extra could ship green — which is how the mcp 2.x break
+  reached a release. The job now installs `[dev,engine,mcp]` and asserts the
+  extra imports before running the suite.
+
 ### Changed
+- **Python 3.13 and 3.14 are now tested in CI.** `requires-python` has always
+  accepted them and the classifiers already advertised 3.13, but the test
+  matrix stopped at 3.12. It now covers 3.10 through 3.14, and 3.14 is declared
+  in the classifiers to match.
 - **Discord links now point at the `#start-here` invite** (#132).
   `README.md`, `CONTRIBUTING.md`, `pyproject.toml`, the new-issue chooser, and
   the community and plugins docs pages used `discord.gg/WgTMpmSFtN`, which

--- a/humanbound_cli/commands/mcp.py
+++ b/humanbound_cli/commands/mcp.py
@@ -28,8 +28,10 @@ def mcp_command():
     """
     try:
         from ..mcp_server import main
-    except ImportError:
+    except ImportError as e:
         raise click.ClickException(
-            "MCP dependencies not installed. Run: pip install humanbound[mcp]"
-        )
+            "The MCP server requires the [mcp] extra. "
+            "Install with: pip install 'humanbound[mcp]'\n"
+            f"  (import failed: {e})"
+        ) from e
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Environment :: Console",
     "Framework :: Pytest",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/tests/unit/test_mcp_command.py
+++ b/tests/unit/test_mcp_command.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2026 Humanbound
+"""`hb mcp` must say why the MCP import failed, not just that it did.
+
+A missing SDK and an incompatible one need different fixes, so the error keeps
+the install command first and the underlying cause as a labelled detail.
+"""
+
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from humanbound_cli.main import cli
+
+MCP_SERVER = "humanbound_cli.mcp_server"
+
+ABSENT = "No module named 'mcp'"
+INCOMPATIBLE = (
+    "No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer"
+)
+
+
+class _RaisingFinder:
+    """Meta-path finder that fails one module with a chosen ImportError."""
+
+    def __init__(self, target: str, exc: ImportError):
+        self._target = target
+        self._exc = exc
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == self._target:
+            raise self._exc
+        return None
+
+
+def _run_hb_mcp(monkeypatch, message: str):
+    """Invoke `hb mcp` with the MCP server import failing with `message`."""
+    monkeypatch.delitem(sys.modules, MCP_SERVER, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [_RaisingFinder(MCP_SERVER, ModuleNotFoundError(message))] + sys.meta_path,
+    )
+    return CliRunner().invoke(cli, ["mcp"])
+
+
+@pytest.mark.parametrize("message", [ABSENT, INCOMPATIBLE])
+def test_underlying_import_error_reaches_the_user(monkeypatch, message):
+    result = _run_hb_mcp(monkeypatch, message)
+
+    assert result.exit_code != 0
+    assert message in result.output, result.output
+    assert "pip install 'humanbound[mcp]'" in result.output
+
+
+def test_the_actionable_line_comes_before_the_details(monkeypatch):
+    """The install command is the headline; the raw cause stays secondary."""
+    output = _run_hb_mcp(monkeypatch, ABSENT).output
+
+    assert output.index("pip install") < output.index(ABSENT)
+
+
+def test_distinct_causes_produce_distinct_messages(monkeypatch):
+    absent = _run_hb_mcp(monkeypatch, ABSENT).output
+    incompatible = _run_hb_mcp(monkeypatch, INCOMPATIBLE).output
+
+    assert absent != incompatible


### PR DESCRIPTION
## Summary

`hb mcp` collapsed every import failure into "MCP dependencies not installed", which was wrong whenever the SDK was present but unusable — notably the mcp 2.x break, where the SDK's own error names the fix. The handler now leads with the install command and carries the underlying `ImportError` as a labelled detail, matching the engine-extra precedent in `bot.py` and the parenthesized-cause style in `auth.py`:

```
Error: The MCP server requires the [mcp] extra. Install with: pip install 'humanbound[mcp]'
  (import failed: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed …)
```

The break shipped in the first place because CI never installed the `[mcp]` extra: `pytest.importorskip("mcp")` silently skipped the whole MCP suite, so an unusable extra went green. The test job now installs `[dev,engine,mcp]` and asserts the extra imports before running the suite.

Also extends the CI matrix to Python 3.13 and 3.14 (both already accepted by `requires-python`; 3.13 was advertised in the classifiers but untested) and declares 3.14 support. Verified locally: full suite green on 3.13.14 and 3.14.6, plus an offline end-to-end local-engine run and a live MCP stdio handshake on 3.14.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Build / tooling / CI

## Checklist

- [x] Tests added for new behavior / regression covered for a bug fix
- [x] `pytest`, `ruff check`, and `ruff format --check` pass locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs updated on `docs.humanbound.ai` (if the change is user-visible) — not needed: docs state "Python 3.10 or higher", which remains accurate, and the error text isn't documented
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/humanbound/blob/main/DCO.md)

## Linked issue(s)

Fixes #135